### PR TITLE
Allow users to save default password type and length

### DIFF
--- a/CommonGeneratorCode/Password.cs
+++ b/CommonGeneratorCode/Password.cs
@@ -73,7 +73,7 @@ namespace CommonGeneratorCode
         Strong,
     };
 
-    public class Password
+    public record Password
     {
         private static readonly IReadOnlyList<char> NumericCharacters = new List<char>()
                 {
@@ -148,6 +148,24 @@ namespace CommonGeneratorCode
         }
 
         public double StrengthInBits { get; private set; }
+
+        public static bool IsValidPasswordLength(int lengthInCharacters) => 
+            lengthInCharacters is >= Constants.MinimumPasswordLengthInChars and <= Constants.MaximumPasswordLengthInChars;
+
+        public static bool IsValidPasswordType(PasswordType passwordType)
+        {
+            switch (passwordType)
+            {
+                case PasswordType.AnyKeyOnAnEnglishKeyboard:
+                case PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace:
+                case PasswordType.AlphaNumeric:
+                case PasswordType.Numeric:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
 
         private static IReadOnlyList<char> GetCharactersWhichCanBeInPasswordList(PasswordType passwordType)
         {

--- a/CommonGeneratorCode/ServiceFactory.cs
+++ b/CommonGeneratorCode/ServiceFactory.cs
@@ -1,0 +1,132 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace CommonGeneratorCode
+{
+    public class ServiceFactory
+    {
+        private Dictionary<Type, ServiceMetadata> registeredServiceDictionary;
+
+        public ServiceFactory()
+        {
+            this.registeredServiceDictionary = new Dictionary<Type, ServiceMetadata>();
+        }
+
+        public void RegisterSingletonService<TServiceInterfaceType, TServiceType>()
+            where TServiceInterfaceType : class
+            where TServiceType : class, TServiceInterfaceType
+        {
+            Type serviceInterfaceType = typeof(TServiceInterfaceType);
+            Type serviceType = typeof(TServiceType);
+
+            if (!serviceInterfaceType.IsInterface)
+            {
+                throw new ArgumentException(
+                    message: $"{nameof(TServiceInterfaceType)} must contain an interface type.  Here is the type it contained: {serviceInterfaceType.FullName}",
+                    paramName: nameof(TServiceInterfaceType));
+            }
+
+            if (!serviceType.IsClass)
+            {
+                throw new ArgumentException(
+                    message: $"{nameof(TServiceType)} must contain a class.  Here is the type it contained: {serviceType.FullName}",
+                    paramName: nameof(TServiceType));
+            }
+
+            ConstructorInfo[] constructors = serviceType.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
+            if (constructors.Length != 1)
+            {
+                throw new ArgumentException(
+                    "Services can only have one public constructor.",
+                    paramName: nameof(TServiceType));
+            }
+
+            if (ServiceRegistered(serviceInterfaceType))
+            {
+                throw new ArgumentException(
+                    $"Cannot register a service because a service of type {serviceInterfaceType.FullName} has already been registered.",
+                    paramName: nameof(TServiceInterfaceType));
+            }
+
+            this.registeredServiceDictionary[serviceInterfaceType] = new ServiceMetadata(typeof(TServiceType), isSingleton: true);
+        }
+
+        public TServiceInterfaceType GetService<TServiceInterfaceType>()
+            where TServiceInterfaceType : class
+        {
+            return (TServiceInterfaceType)this.GetService(typeof(TServiceInterfaceType));
+        }
+
+        private object GetService(Type serviceInterfaceType)
+        {
+            if (!ServiceRegistered(serviceInterfaceType))
+            {
+                throw new ArgumentException($"Cannot get the service because a service of type {serviceInterfaceType.FullName} has not been registered.");
+            }
+
+            ServiceMetadata serviceMetadata = this.registeredServiceDictionary[serviceInterfaceType];
+
+            if (serviceMetadata.IsSingletonService && (serviceMetadata.SingletonServiceInstance != null))
+            {
+                return serviceMetadata.SingletonServiceInstance;
+            }
+
+            ConstructorInfo[] constructors = serviceMetadata.ServiceType.GetConstructors(BindingFlags.Instance | BindingFlags.Public);
+
+            Debug.Assert(
+                constructors.Length == 1,
+                "Services are only allowed one public constructor because there is no easy way to determine which constructor to use if a " +
+                "service has multiple constructors.  This requirement is checked in RegisterSingletonService().");
+
+            ConstructorInfo serviceConstructor = constructors[0];
+            ParameterInfo[] serviceConstructorParametersMetadata = serviceConstructor.GetParameters();
+            object[] constructorParameters = new object[serviceConstructorParametersMetadata.Length];
+
+            // Get the constructor's parameter values
+            for (int parameterIndex = 0; parameterIndex < constructorParameters.Length; parameterIndex++)
+            {
+                ParameterInfo currentParameterMetadata = serviceConstructorParametersMetadata[parameterIndex];
+
+                // Services are only allowed to have parameters which are other services.
+                constructorParameters[parameterIndex] = this.GetService(currentParameterMetadata.ParameterType);
+            }
+
+            object newServiceInstance = serviceConstructor.Invoke(constructorParameters);
+
+            if (serviceMetadata.IsSingletonService)
+            {
+                serviceMetadata.SingletonServiceInstance = newServiceInstance;
+            }
+
+            return newServiceInstance;
+        }
+
+        private bool ServiceRegistered(Type serviceInterfaceType) => this.registeredServiceDictionary.ContainsKey(serviceInterfaceType);
+    }
+}

--- a/CommonGeneratorCode/ServiceMetadata.cs
+++ b/CommonGeneratorCode/ServiceMetadata.cs
@@ -1,0 +1,72 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+
+namespace CommonGeneratorCode
+{
+    public class ServiceMetadata
+    {
+        private object singletonServiceInstance;
+
+        public ServiceMetadata(Type serviceType, bool isSingleton)
+        {
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
+            this.ServiceType = serviceType;
+            this.IsSingletonService = isSingleton;
+            this.SingletonServiceInstance = null;
+        }
+
+        public Type ServiceType { get; init; }
+
+        public bool IsSingletonService { get; init; }
+
+        public object SingletonServiceInstance
+        {
+            get
+            {
+                if (!this.IsSingletonService)
+                {
+                    throw new InvalidOperationException($"{nameof(this.SingletonServiceInstance)} should only be called if a service is a singleton service.");
+                }
+
+                return this.singletonServiceInstance;
+            }
+
+            set
+            {
+                if ((value != null) && (value.GetType() != this.ServiceType))
+                {
+                    throw new InvalidOperationException($"Only values of type {this.ServiceType.FullName} can be passed to {nameof(this.SingletonServiceInstance)}.");
+                }
+
+                this.singletonServiceInstance = value;
+            }
+        }
+    }
+}

--- a/CommonGeneratorCodeUnitTests/CommonGeneratorCodeUnitTests.csproj
+++ b/CommonGeneratorCodeUnitTests/CommonGeneratorCodeUnitTests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CommonGeneratorCode\CommonGeneratorCode.csproj" />
+    <ProjectReference Include="..\TestUtil\TestUtil.csproj" />
   </ItemGroup>
 
 </Project>

--- a/CommonGeneratorCodeUnitTests/ServiceFactoryUnitTests.cs
+++ b/CommonGeneratorCodeUnitTests/ServiceFactoryUnitTests.cs
@@ -1,0 +1,180 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using TestUtil;
+using CommonGeneratorCode;
+using CommonGeneratorCodeUnitTests.TestServiceFactories;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace CommonGeneratorCodeUnitTests
+{
+    [TestClass]
+    public class ServiceFactoryUnitTests
+    {
+        private ServiceFactory serviceFactory;
+
+        // This method runs before each test
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.serviceFactory = new ServiceFactory();
+
+            // The order of service registrations should not matter.
+            serviceFactory.RegisterSingletonService<ITestServiceWith_1_Dependency, TestServiceWith_1_Dependency>();
+            serviceFactory.RegisterSingletonService<ITestServiceWith_2_Dependencies, TestServiceWith_2_Dependencies>();
+            serviceFactory.RegisterSingletonService<ITestServiceWithNoDepenedencies, TestServiceWithNoDepenedencies>();
+        }
+
+        // This method runs after each test
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            this.serviceFactory = null;
+        }
+
+        [TestMethod]
+        public void ServiceFactoryShouldBeAbleToCreateAServiceWith_No_Dependencies()
+        {
+            this.ServiceFactoryShouldBeAbleToCreateAService<ITestServiceWithNoDepenedencies, TestServiceWithNoDepenedencies>();
+        }
+
+        [TestMethod]
+        public void ServiceFactoryShouldBeAbleToCreateAServiceWith_1_Dependency()
+        {
+            this.ServiceFactoryShouldBeAbleToCreateAService<ITestServiceWith_1_Dependency, TestServiceWith_1_Dependency>();
+            AssertTestServiceWith_1_DependencyIsCorrectlyConfigured(serviceFactory.GetService<ITestServiceWith_1_Dependency>());
+        }
+
+        [TestMethod]
+        public void ServiceFactoryShouldBeAbleToCreateAServiceWith_2_Dependencies()
+        {
+            this.ServiceFactoryShouldBeAbleToCreateAService<ITestServiceWith_2_Dependencies, TestServiceWith_2_Dependencies>();
+
+            TestServiceWith_2_Dependencies testServiceImplementation =
+                GetServiceImplementation<ITestServiceWith_2_Dependencies, TestServiceWith_2_Dependencies>();
+
+            AssertDependencySet(testServiceImplementation.TestServiceWithNoDepenedencies);
+            AssertDependencySet(testServiceImplementation.TestServiceWith_1_Dependency);
+            AssertTestServiceWith_1_DependencyIsCorrectlyConfigured(testServiceImplementation.TestServiceWith_1_Dependency);
+        }
+
+        [TestMethod]
+        public void ServiceFactoryShouldAlwaysReturnTheSameInstanceForSingletonServices()
+        {
+            ITestServiceWith_2_Dependencies singletonService = this.serviceFactory.GetService<ITestServiceWith_2_Dependencies>();
+            Assert.IsNotNull(singletonService, "The service should exist");
+
+            // The choice of 10 is an arbitrary number.
+            for (int numberOfTimesToTest = 0; numberOfTimesToTest < 10; numberOfTimesToTest++)
+            {
+                ITestServiceWith_2_Dependencies currentSingletonService = this.serviceFactory.GetService<ITestServiceWith_2_Dependencies>();
+                Assert.IsTrue(
+                    object.ReferenceEquals(singletonService, currentSingletonService), 
+                    "GetService() should always return the same instance of a singleton service.");
+            }    
+        }
+
+        [TestMethod]
+        public void ServiceFactoryShouldThrowAnExceptionIfAnUnregisteredServiceIsRequested()
+        {
+            // No registered service implements the ITestDataSource interface.
+            TestHelper.TestActionWhichShouldThrowAnException<ArgumentException>(
+                () => this.serviceFactory.GetService<ITestDataSource>(),
+                $"Cannot get the service because a service of type {typeof(ITestDataSource).FullName} has not been registered.");
+        }
+
+        [TestMethod]
+        public void RegisterSingletonServiceShouldThrowAnExceptionIfIts_TServiceInterfaceType_ParameterDoesNotContainAnInterface()
+        {
+            // Note that the first type parameter is a class, not an interface like it should be.
+            TestHelper.TestActionWhichShouldThrowAnException<ArgumentException>(
+                () => this.serviceFactory.RegisterSingletonService<TestServiceWithNoDepenedencies, TestServiceWithNoDepenedencies>(),
+                
+                $"TServiceInterfaceType must contain an interface type.  Here is the type it contained: " +
+                $"{typeof(TestServiceWithNoDepenedencies).FullName}" );
+        }
+
+        [TestMethod]
+        public void RegisterSingletonServiceShouldThrowAnExceptionIfIts_TServiceType_ParameterDoesNotContainAClass()
+        {
+            // Note that the second type parameter is an interface, not a class like it should be.
+            TestHelper.TestActionWhichShouldThrowAnException<ArgumentException>(
+                () => this.serviceFactory.RegisterSingletonService<ITestServiceWithNoDepenedencies, ITestServiceWithNoDepenedencies>(),
+                
+                $"TServiceType must contain a class.  Here is the type it contained: " +
+                $"{typeof(ITestServiceWithNoDepenedencies).FullName}");
+        }
+
+        [TestMethod]
+        public void RegisterSingletonServiceShouldThrowAnExceptionIfIts_TServiceType_HasMultipleConstructors()
+        {
+            TestHelper.TestActionWhichShouldThrowAnException<ArgumentException>(
+                () => this.serviceFactory.RegisterSingletonService<IInvalidServiceWithMultipleConstructors, InvalidServiceWithMultipleConstructors>(),
+                "Services can only have one public constructor.");
+        }
+
+        [TestMethod]
+        public void RegisterSingletonServiceShouldThrowAnExceptionIfAServiceHasAlreadyBeenRegistered()
+        {
+            TestHelper.TestActionWhichShouldThrowAnException<ArgumentException>(
+                () => this.serviceFactory.RegisterSingletonService<ITestServiceWithNoDepenedencies, TestServiceWithNoDepenedencies>(),
+                $"Cannot register a service because a service of type {typeof(ITestServiceWithNoDepenedencies).FullName} has already been registered.");
+        }
+
+
+
+        private void ServiceFactoryShouldBeAbleToCreateAService<TServiceInterfaceType, TServiceType>()
+            where TServiceInterfaceType : class
+            where TServiceType : class
+        {
+            TServiceInterfaceType requestedService = this.serviceFactory.GetService<TServiceInterfaceType>();
+            Type requestedServiceType = ((object)requestedService).GetType();
+            Assert.IsTrue(
+                requestedServiceType == typeof(TServiceType),
+                "The service factory should create the object specified in the call to RegisterSingletonService()");
+        }
+
+        private TServiceType GetServiceImplementation<TServiceInterfaceType, TServiceType>()
+            where TServiceInterfaceType : class
+            where TServiceType : class
+        {
+            TServiceInterfaceType requestedService = this.serviceFactory.GetService<TServiceInterfaceType>();
+            TServiceType serviceImplementation = requestedService as TServiceType;
+            Assert.IsNotNull(serviceImplementation, "The service does not have the expected implementation.");
+            return serviceImplementation;
+        }
+
+        private static void AssertTestServiceWith_1_DependencyIsCorrectlyConfigured(ITestServiceWith_1_Dependency testServiceWith_1_Dependency)
+        {
+            TestServiceWith_1_Dependency requestedImplementation = (TestServiceWith_1_Dependency)testServiceWith_1_Dependency;
+            AssertDependencySet(requestedImplementation.TestServiceWithNoDepenedencies);
+        }
+
+        private static void AssertDependencySet<TServiceInterfaceType>(TServiceInterfaceType service)
+        {
+            Assert.IsNotNull(service, "The service should have its dependencies set.");
+        }
+    }
+}

--- a/CommonGeneratorCodeUnitTests/TestServiceFactories/InvalidServiceWithMultipleConstructors.cs
+++ b/CommonGeneratorCodeUnitTests/TestServiceFactories/InvalidServiceWithMultipleConstructors.cs
@@ -1,0 +1,53 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+
+namespace CommonGeneratorCodeUnitTests.TestServiceFactories
+{
+    public interface IInvalidServiceWithMultipleConstructors
+    {
+        void Foo2();
+    }
+
+    public class InvalidServiceWithMultipleConstructors : IInvalidServiceWithMultipleConstructors
+    {
+        public InvalidServiceWithMultipleConstructors()
+        {
+            this.TestServiceWithNoDepenedencies = null;
+        }
+
+        public InvalidServiceWithMultipleConstructors(ITestServiceWithNoDepenedencies testServiceWithNoDepenedencies)
+        {
+            this.TestServiceWithNoDepenedencies = testServiceWithNoDepenedencies;
+        }
+
+        ITestServiceWithNoDepenedencies TestServiceWithNoDepenedencies { get; init; }
+
+        public void Foo2()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWithNoDepenedencies.cs
+++ b/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWithNoDepenedencies.cs
@@ -1,0 +1,44 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+
+namespace CommonGeneratorCodeUnitTests.TestServiceFactories
+{
+    public interface ITestServiceWithNoDepenedencies
+    {
+        void Foo();
+    }
+
+    /// <summary>
+    /// This class tests the case where a service has no dependencies and no explicit constructor.
+    /// </summary>
+    public class TestServiceWithNoDepenedencies : ITestServiceWithNoDepenedencies
+    {
+        public void Foo()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWith_1_Dependency.cs
+++ b/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWith_1_Dependency.cs
@@ -1,0 +1,48 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+
+namespace CommonGeneratorCodeUnitTests.TestServiceFactories
+{
+    public interface ITestServiceWith_1_Dependency
+    {
+        int Baz();
+    }
+
+    public class TestServiceWith_1_Dependency : ITestServiceWith_1_Dependency
+    {
+        public TestServiceWith_1_Dependency(ITestServiceWithNoDepenedencies testServiceWithNoDepenedencies)
+        {
+            this.TestServiceWithNoDepenedencies = testServiceWithNoDepenedencies;
+        }
+
+        public ITestServiceWithNoDepenedencies TestServiceWithNoDepenedencies { get; init; }
+
+        public int Baz()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWith_2_Dependencies.cs
+++ b/CommonGeneratorCodeUnitTests/TestServiceFactories/TestServiceWith_2_Dependencies.cs
@@ -1,0 +1,51 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System;
+
+namespace CommonGeneratorCodeUnitTests.TestServiceFactories
+{
+    interface ITestServiceWith_2_Dependencies
+    {
+        void Bar();
+    }
+
+    public class TestServiceWith_2_Dependencies : ITestServiceWith_2_Dependencies
+    {
+        public TestServiceWith_2_Dependencies(ITestServiceWith_1_Dependency testServiceWith_1_Dependency, ITestServiceWithNoDepenedencies testServiceWithNoDepenedencies)
+        {
+            this.TestServiceWith_1_Dependency = testServiceWith_1_Dependency;
+            this.TestServiceWithNoDepenedencies = testServiceWithNoDepenedencies;
+        }
+
+        public ITestServiceWithNoDepenedencies TestServiceWithNoDepenedencies { get; init; }
+
+        public ITestServiceWith_1_Dependency TestServiceWith_1_Dependency { get; init; }
+
+        public void Bar()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/EasyToUseGenerator/App.xaml
+++ b/EasyToUseGenerator/App.xaml
@@ -84,7 +84,7 @@
         <!-- This style is based on the standard WPF Aero 2 Theme button style.  Here is a link to the style: 
              https://github.com/dotnet/wpf/blob/1d2877a0dfcb45762cc080a24fd81ba970be8a4c/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml#L7214 
         
-             Also based the FocusVisual style one of the WPF Aero 2 Theme Focus Visual styles.  Here is a link to the style:
+             It is also based the WPF Aero 2 Theme FocusVisual.  Here is a link to the style:
              https://github.com/dotnet/wpf/blob/1d2877a0dfcb45762cc080a24fd81ba970be8a4c/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml#L2240 
         -->
         <Style x:Key="StandardButtonStyle"
@@ -114,6 +114,7 @@
                                     <Rectangle Stroke="White"
                                                StrokeDashArray="1 1"
                                                StrokeThickness="1"
+                                               SnapsToDevicePixels="true" 
                                                Margin="2"/>
                                 </ControlTemplate>
                             </Setter.Value>
@@ -164,17 +165,131 @@
             </Setter>
         </Style>
 
+        
+        
+        <!-- This style is based on the standard WPF Aero 2 Theme check box style.  Here is a link to the style: 
+             https://github.com/dotnet/wpf/blob/33fe5e923be3ed119ff07b87e816afb5f80efe64/src/Microsoft.DotNet.Wpf/src/Themes/XAML/CheckBox.xaml#L338
+        
+             It is also based the WPF Aero 2 Theme FocusVisual and OptionMarkFocusVisual styles.  Here is a link to the styles:
+             https://github.com/dotnet/wpf/blob/8d0186b93161bf503e53235e6ea7afcfea610d2b/src/Microsoft.DotNet.Wpf/src/Themes/XAML/FocusVisual.xaml#L65
+        
+             Here are the changes made to the style:
+             - Changed a lot of the colors so they fit into the app's black, white and gray color scheme.
+             - Removed the handling for the IsEnabled state from the control template.  The reason is the check box is always enabled.
+          -->
+        <Style x:Key="StandardCheckBoxStyle"
+               TargetType="{x:Type CheckBox}">
+            <Setter Property="Background" Value="White" />
+            <Setter Property="BorderBrush" Value="Black" />
+            <Setter Property="Foreground" Value="Black" />
+            <Setter Property="BorderThickness" Value="1" />
+
+            <Setter Property="FocusVisualStyle">
+                <Setter.Value>
+                    <Style>
+                        <Setter Property="Control.Template">
+                            <Setter.Value>
+                                <ControlTemplate>
+                                    <Rectangle Stroke="Black"
+                                               StrokeDashArray="1 2"
+                                               StrokeThickness="1"
+                                               SnapsToDevicePixels="true" 
+                                               Margin="2"/>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                    </Style>
+                </Setter.Value>
+            </Setter>
+
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type CheckBox}">
+                        <Grid x:Name="templateRoot" SnapsToDevicePixels="True" Background="Transparent">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            
+                            <Border x:Name="checkBoxBorder" 
+                                    Margin="1" 
+                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                                    BorderThickness="{TemplateBinding BorderThickness}" 
+                                    Background="{TemplateBinding Background}" 
+                                    BorderBrush="{TemplateBinding BorderBrush}">
+                                <Grid x:Name="markGrid">
+                                    <Path x:Name="optionMark" Opacity="0" Stretch="None" Margin="1" Fill="Black" Data="F1 M 9.97498,1.22334L 4.6983,9.09834L 4.52164,9.09834L 0,5.19331L 1.27664,3.52165L 4.255,6.08833L 8.33331,1.52588e-005L 9.97498,1.22334 Z "/>
+                                    <Rectangle x:Name="indeterminateMark" Margin="2" Opacity="0" Fill="Black" />
+                                </Grid>
+                            </Border>
+                            
+                            <ContentPresenter x:Name="contentPresenter" 
+                                              RecognizesAccessKey="True" 
+                                              Grid.Column="1" 
+                                              Margin="{TemplateBinding Padding}" 
+                                              SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" 
+                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                                              Focusable="False"/>
+                        </Grid>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="HasContent" Value="true">
+                                <Setter Property="FocusVisualStyle">
+                                    <Setter.Value>
+                                        <Style>
+                                            <Setter Property="Control.Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate>
+                                                        <Rectangle Stroke="Black" 
+                                                                   StrokeDashArray="1 2"
+                                                                   StrokeThickness="1" 
+                                                                   Margin="16,0,0,0" />
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </Setter.Value>
+                                </Setter>
+                                <Setter Property="Padding" Value="4,-1,0,0"/>
+                            </Trigger>
+                            <Trigger Property="IsMouseOver" Value="true">
+                                <Setter Property="Background" Value="LightGray" TargetName="checkBoxBorder" />
+                                <Setter Property="BorderBrush" Value="Gray" TargetName="checkBoxBorder" />
+                                <Setter Property="Fill" Value="Black" TargetName="optionMark" />
+                                <Setter Property="Fill" Value="Black" TargetName="indeterminateMark" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="true">
+                                <Setter Property="Background" Value="LightGray" TargetName="checkBoxBorder" />
+                                <Setter Property="BorderBrush" Value="Gray" TargetName="checkBoxBorder" />
+                                <Setter Property="Fill" Value="Gray" TargetName="optionMark" />
+                                <Setter Property="Fill" Value="Gray" TargetName="indeterminateMark" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="true">
+                                <Setter Property="Opacity" Value="1" TargetName="optionMark" />
+                                <Setter Property="Opacity" Value="0" TargetName="indeterminateMark" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="{x:Null}">
+                                <Setter Property="Opacity" Value="0" TargetName="optionMark" />
+                                <Setter Property="Opacity" Value="1" TargetName="indeterminateMark" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
 
 
         <!-- 
-        If this value is updated, the width of Grid column 2 is the StandardWindowControlTemplate control template should also be updated. 
+        If this value is updated, the width of Grid column 2 in the StandardWindowControlTemplate control template should also be updated. 
             
         Column 2 cannot reference this value because it expects a GridLength object and this object is a Double.  There is no easy way
         to convert a double to a GridLength object in XAML.
         -->
         <system:Double x:Key="WindowTitleBarHeightInPixels">30</system:Double>
        
-        
+       
         
         <Style x:Key="WindowChromeButtonStyle"
                      BasedOn="{StaticResource StandardButtonStyle}"

--- a/EasyToUseGenerator/App.xaml
+++ b/EasyToUseGenerator/App.xaml
@@ -84,7 +84,7 @@
         <!-- This style is based on the standard WPF Aero 2 Theme button style.  Here is a link to the style: 
              https://github.com/dotnet/wpf/blob/1d2877a0dfcb45762cc080a24fd81ba970be8a4c/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml#L7214 
         
-             It is also based the WPF Aero 2 Theme FocusVisual.  Here is a link to the style:
+             It is also based on the WPF Aero 2 Theme FocusVisual style.  Here is a link to the style:
              https://github.com/dotnet/wpf/blob/1d2877a0dfcb45762cc080a24fd81ba970be8a4c/src/Microsoft.DotNet.Wpf/src/Themes/PresentationFramework.Aero2/Themes/Aero2.NormalColor.xaml#L2240 
         -->
         <Style x:Key="StandardButtonStyle"
@@ -170,7 +170,7 @@
         <!-- This style is based on the standard WPF Aero 2 Theme check box style.  Here is a link to the style: 
              https://github.com/dotnet/wpf/blob/33fe5e923be3ed119ff07b87e816afb5f80efe64/src/Microsoft.DotNet.Wpf/src/Themes/XAML/CheckBox.xaml#L338
         
-             It is also based the WPF Aero 2 Theme FocusVisual and OptionMarkFocusVisual styles.  Here is a link to the styles:
+             It is also based on the WPF Aero 2 Theme FocusVisual and OptionMarkFocusVisual styles.  Here is a link to the styles:
              https://github.com/dotnet/wpf/blob/8d0186b93161bf503e53235e6ea7afcfea610d2b/src/Microsoft.DotNet.Wpf/src/Themes/XAML/FocusVisual.xaml#L65
         
              Here are the changes made to the style:

--- a/EasyToUseGenerator/App.xaml
+++ b/EasyToUseGenerator/App.xaml
@@ -28,7 +28,9 @@
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:local="clr-namespace:EasyToUseGenerator"             
              
-             StartupUri="MainWindow.xaml">
+             StartupUri="MainWindow.xaml"
+             
+             Exit="OnExit">
 
     <Application.Resources>
 

--- a/EasyToUseGenerator/App.xaml.cs
+++ b/EasyToUseGenerator/App.xaml.cs
@@ -22,11 +22,31 @@
 // SOFTWARE.
 //
 
+using CommonGeneratorCode;
 using System.Windows;
 
 namespace EasyToUseGenerator
 {
     public partial class App : Application
     {
+        private ServiceFactory serviceFactory;
+
+        public App()
+        {
+            this.serviceFactory = new ServiceFactory();
+            this.serviceFactory.RegisterSingletonService<IAppSettingService, AppSettings>();
+            this.serviceFactory.RegisterSingletonService<ITextFileService, TextFileService>();
+
+            this.Settings = this.serviceFactory.GetService<IAppSettingService>();
+        }
+
+        public static new App Current => (App)Application.Current;
+        
+        public IAppSettingService Settings { get; init; }
+
+        private void OnExit(object sender, ExitEventArgs e)
+        {
+            this.Settings.Save();
+        }
     }
 }

--- a/EasyToUseGenerator/AppSettings.cs
+++ b/EasyToUseGenerator/AppSettings.cs
@@ -1,0 +1,159 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+using CommonGeneratorCode;
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EasyToUseGenerator
+{
+    public interface IAppSettingService
+    {
+        public int DefaultPasswordLengthInChars { get; set; }
+
+        public PasswordType DefaultPasswordType { get; set; }
+
+        public void Save();
+    }
+
+    public class AppSettings : IAppSettingService
+    {
+        private readonly ITextFileService textFileService;
+
+        private readonly JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions()
+        {
+            MaxDepth = 2,
+            Encoder = null, // Use the default encoder
+
+            DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+            Converters =
+                {
+                    new JsonStringEnumConverter(namingPolicy: null, allowIntegerValues: false)
+                },
+
+            IgnoreReadOnlyFields = true,
+            IgnoreReadOnlyProperties = true,
+            IncludeFields = false,
+
+            AllowTrailingCommas = false,
+            NumberHandling = JsonNumberHandling.Strict,
+            ReadCommentHandling = JsonCommentHandling.Disallow,
+            PropertyNameCaseInsensitive = false,
+
+            WriteIndented = true,
+        };
+
+        public AppSettings(ITextFileService textFileService)
+        {
+            this.textFileService = textFileService;
+            this.InitializeSettings();
+        }
+
+        public int DefaultPasswordLengthInChars { get; set; }
+
+        public PasswordType DefaultPasswordType { get; set; }
+
+        public void Save()
+        {
+            SerializedSettings serializedSettings = new SerializedSettings(this);
+            string jsonSerializedSettings = JsonSerializer.Serialize<SerializedSettings>(serializedSettings, jsonSerializerOptions);
+            this.textFileService.CreateDirectoryIfItDoesNotExist(this.SettingsFileDirectoryPath);
+            this.textFileService.WriteTextFile(this.SettingsFileNamePath, jsonSerializedSettings);
+        }
+
+        private string SettingsFileDirectoryPath
+        {
+            get
+            {
+                const string ApplicationName = "Generator";
+
+                string roamingAppDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                return Path.Combine(roamingAppDataFolder, ApplicationName);
+            }
+        }
+
+        private string SettingsFileNamePath
+        {
+            get
+            {
+                const string SettingsFileName = "GeneratorSettings.json";
+
+                return Path.Combine(this.SettingsFileDirectoryPath, SettingsFileName);
+            }
+        }
+
+        private void InitializeSettings()
+        {
+            this.DefaultPasswordType = Constants.InitialDefaultPasswordType;
+            this.DefaultPasswordLengthInChars = Constants.InitialDefaultPasswordLengthInChars;
+
+            string jsonSerializedSettings;
+
+            if (this.textFileService.TryReadTextFile(this.SettingsFileNamePath, out jsonSerializedSettings))
+            {
+                SerializedSettings serializedSettings = JsonSerializer.Deserialize<SerializedSettings>(jsonSerializedSettings, jsonSerializerOptions);
+                
+                // Ignore invalid settings stored in the configuration file.
+                
+                // The GUI version of this application does not support passwords with spaces.
+                if (Password.IsValidPasswordType(serializedSettings.DefaultPasswordType) &&
+                    (serializedSettings.DefaultPasswordType != PasswordType.AnyKeyOnAnEnglishKeyboard))
+                {
+                    this.DefaultPasswordType = serializedSettings.DefaultPasswordType;
+                }
+
+                if (Password.IsValidPasswordLength(serializedSettings.DefaultPasswordLengthInChars))
+                {
+                    this.DefaultPasswordLengthInChars = serializedSettings.DefaultPasswordLengthInChars;
+                }
+            }
+        }
+
+        /// <summary>
+        /// This class is used to serialize and decerialize the settings into JSON.
+        /// </summary>
+        public class SerializedSettings
+        {
+            public SerializedSettings()
+            {
+                // Set the initial values in case they are not in the configuration file.  JsonSerializer.Deserialize<SerializedSettings>()
+                // does not throw an error if a JSON file does not contain an expected property.  Instead, it leaves the property's value as
+                // the default value.
+                this.DefaultPasswordType = Constants.InitialDefaultPasswordType;
+                this.DefaultPasswordLengthInChars = Constants.InitialDefaultPasswordLengthInChars;
+            }
+
+            public SerializedSettings(AppSettings appSettings)
+            {
+                this.DefaultPasswordType = appSettings.DefaultPasswordType;
+                this.DefaultPasswordLengthInChars = appSettings.DefaultPasswordLengthInChars;
+            }
+
+            public PasswordType DefaultPasswordType { get; set; } 
+
+            public int DefaultPasswordLengthInChars { get; set; }
+        }
+    }
+}

--- a/EasyToUseGenerator/AppSettings.cs
+++ b/EasyToUseGenerator/AppSettings.cs
@@ -132,7 +132,7 @@ namespace EasyToUseGenerator
         }
 
         /// <summary>
-        /// This class is used to serialize and decerialize the settings into JSON.
+        /// This class is used to convert the app's settings to and from JSON.
         /// </summary>
         public class SerializedSettings
         {

--- a/EasyToUseGenerator/Constants.cs
+++ b/EasyToUseGenerator/Constants.cs
@@ -1,0 +1,36 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using CommonGeneratorCode;
+
+namespace EasyToUseGenerator
+{
+    public static class Constants
+    {
+        // These values are used if there is no settings JSON file or if the file contains invalid data.
+        public const PasswordType InitialDefaultPasswordType = PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace;
+
+        public const int InitialDefaultPasswordLengthInChars = 20;
+    }
+}

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -102,7 +102,7 @@
         <CheckBox Content="Update default password length and type"
                   IsChecked="{Binding ShouldUpdateDefaultPasswordCharacteristics, Mode=TwoWay}"
                   
-                  Foreground="Black"
+                  Style="{StaticResource StandardCheckBoxStyle}"
                   
                   Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"/>
 

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -36,14 +36,15 @@
                                             
                       TitleBarBackground="DarkSlateGray"
                       
-                      Height="230" 
+                      Height="260" 
                       Width="375">
     
     <!-- TODO - localization -->
     <StackPanel Style="{StaticResource StandardMainStackPanelStyle}">
         <Label Content="Characters which may be included in the new password"
                Target="{Binding ElementName=newPasswordCharacterSetRadioButtonGroupStackPanel}"
-               Style="{StaticResource StandardLabelStyle}"/>
+               Style="{StaticResource StandardLabelStyle}"
+               Margin="0"/>
 
         <StackPanel x:Name="newPasswordCharacterSetRadioButtonGroupStackPanel"
                     Orientation="Vertical">
@@ -55,26 +56,24 @@
                 </Style>
             </StackPanel.Resources>
             
-            <RadioButton x:Name="anyKeyWhichCanBeTypedRadioButton"
-                         Content="Any character which can be typed"
+            <RadioButton Content="Any character which can be typed"
                          ToolTip="Any upper-case letter, lower-case letter, number or symbol character can appear in the password.  Spaces cannot appear in the password."
-                         IsChecked="True"
+                         IsChecked="{Binding IsAnyKeyWhichCanBeTypedRadioButtonChecked, Mode=OneTime}"
                          Click="OnAnyKeyWhichCanBeTypedRadioButtonClicked"
                          
                          Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
 
-            <RadioButton x:Name="alphaNumericPasswordRadioButton"
-                         Content="Letters and numbers"
+            <RadioButton Content="Letters and numbers"
                          ToolTip="Any upper-case letter, lower-case letter or number can appear in the password"
+                         IsChecked="{Binding IsLettersAndNumbersRadioButtonChecked, Mode=OneTime}"
                          Click="OnLettersAndNumbersRadioButtonClicked"
                          
                          Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
 
-            <RadioButton x:Name="pinRadioButton"
-                         GroupName="NewPasswordCharacterSetRadioButtonGroup"
-                         Content="Numbers"
+            <RadioButton Content="Numbers"
                          ToolTip="Any number can appear in the password.  These passwords are usually used for 4 to 6 number passwords called Personal Identification Numbers (PINs)."
                          Click="OnNumbersRadioButtonClicked"
+                         IsChecked="{Binding IsNumbersRadioButtonChecked, Mode=OneTime}"
                          
                          Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
         </StackPanel>
@@ -92,12 +91,20 @@
                  MaxLines="1"   
                  
                  HorizontalAlignment="Left"
+                 HorizontalContentAlignment="Left"
                  
                  BorderBrush="Black"
                  BorderThickness="1"
                  
                  Margin="{StaticResource StandardVerticalSpaceBetweenItemsMargin}"
-                 Width="200"/>
+                 Width="365"/>
+
+        <CheckBox Content="Update default password length and type"
+                  IsChecked="{Binding ShouldUpdateDefaultPasswordCharacteristics, Mode=TwoWay}"
+                  
+                  Foreground="Black"
+                  
+                  Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"/>
 
         <!-- Button Stack Panel -->
         <StackPanel Orientation="Horizontal"

--- a/EasyToUseGenerator/MainWindow.xaml.cs
+++ b/EasyToUseGenerator/MainWindow.xaml.cs
@@ -29,15 +29,13 @@ namespace EasyToUseGenerator
 {
     public partial class MainWindow : StandardWindow
     {
-        private const int DefaultPasswordLengthInChars = 20;
-
         private Password currentPassword;
 
         public MainWindow()
         {
             this.currentPassword = new Password(
-                PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace,
-                passwordLengthInCharacters: DefaultPasswordLengthInChars);
+                App.Current.Settings.DefaultPasswordType,
+                App.Current.Settings.DefaultPasswordLengthInChars);
             this.DataContext = this;
             InitializeComponent();
         }

--- a/EasyToUseGenerator/TextFileService.cs
+++ b/EasyToUseGenerator/TextFileService.cs
@@ -1,0 +1,65 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using System.IO;
+
+namespace EasyToUseGenerator
+{
+    public interface ITextFileService
+    {
+        bool TryReadTextFile(string filePath, out string stringTextFileContent);
+        void WriteTextFile(string filePath, string fileContent);
+
+        void CreateDirectoryIfItDoesNotExist(string directoryPath);
+    }
+
+    public class TextFileService : ITextFileService
+    {
+        public bool TryReadTextFile(string filePath, out string stringTextFileContent)
+        {
+            stringTextFileContent = null;
+
+            if (!File.Exists(filePath))
+            {
+                return false;
+            }
+
+            stringTextFileContent = File.ReadAllText(filePath);
+            return true;
+        }
+
+        public void CreateDirectoryIfItDoesNotExist(string directoryPath)
+        {
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+        }
+
+        public void WriteTextFile(string filePath, string fileContent)
+        {
+            File.WriteAllText(filePath, fileContent);
+        }
+    }
+}

--- a/EasyToUseGeneratorTests/AppSettingsTests.cs
+++ b/EasyToUseGeneratorTests/AppSettingsTests.cs
@@ -50,18 +50,13 @@ namespace EasyToUseGenerator.Tests
         }
 
         [TestMethod]
-        public void AppSettingsShouldLoadSettingsWhichContainTheDefaultValues()
+        public void AppSettingsShouldLoadValidSettings()
         {
-            // The AppSetting class should use the values where were in the settings file's JSON
+            // The AppSetting class should use the values which were in the settings file's JSON
             TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
-                expectedDefaultPasswordType: Constants.InitialDefaultPasswordType, 
+                expectedDefaultPasswordType: Constants.InitialDefaultPasswordType,
                 expectedDefaultPasswordLength: Constants.InitialDefaultPasswordLengthInChars);
-        }
 
-        [TestMethod]
-        public void AppSettingsShouldLoadSettingsWhichContainNonDefaultValues()
-        {
-            // The AppSetting class should use the values where were in the settings file's JSON
             TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
                 expectedDefaultPasswordType: PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace,
                 expectedDefaultPasswordLength: 22);
@@ -104,7 +99,7 @@ namespace EasyToUseGenerator.Tests
             textFileServiceMock.Verify(
                 tfs => tfs.WriteTextFile(
                     It.IsAny<string>(), 
-                    It.Is<string>(str => IsSettingsFileContentValid(str, PasswordType.AlphaNumeric, 10))),
+                    It.Is<string>(json => IsSettingsFileContentValid(json, PasswordType.AlphaNumeric, 10))),
                 Times.Once,
                 "The AppSettings class must correctly write its current settings.");
         }

--- a/EasyToUseGeneratorTests/AppSettingsTests.cs
+++ b/EasyToUseGeneratorTests/AppSettingsTests.cs
@@ -1,0 +1,197 @@
+﻿//
+// MIT License
+//
+// Copyright(c) 2019-2021 Benjamin Ellett
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+using CommonGeneratorCode;
+using EasyToUseGenerator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Moq.Language.Flow;
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace EasyToUseGenerator.Tests
+{
+    [TestClass]
+    public class AppSettingsTests
+    {
+        [TestMethod]
+        public void AppSettingsShouldUseTheDefaultSettingsValuesIfNoSettingsFileExists()
+        {
+            // This test tests the case where the settings file does not exist.
+            (AppSettings appSettings, _) = CreateAppSettingsClass(expectedSettingsFileContent: null);
+
+            // The AppSetting class should use the following values if the settings file does not exist.
+            AssertAppSettingsMatchExpectedValues(
+                appSettings,
+                expectedDefaultPasswordType: Constants.InitialDefaultPasswordType,
+                expectedDefaultPasswordLength: Constants.InitialDefaultPasswordLengthInChars);
+        }
+
+        [TestMethod]
+        public void AppSettingsShouldLoadSettingsWhichContainTheDefaultValues()
+        {
+            // The AppSetting class should use the values where were in the settings file's JSON
+            TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                expectedDefaultPasswordType: Constants.InitialDefaultPasswordType, 
+                expectedDefaultPasswordLength: Constants.InitialDefaultPasswordLengthInChars);
+        }
+
+        [TestMethod]
+        public void AppSettingsShouldLoadSettingsWhichContainNonDefaultValues()
+        {
+            // The AppSetting class should use the values where were in the settings file's JSON
+            TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                expectedDefaultPasswordType: PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace,
+                expectedDefaultPasswordLength: 22);
+
+            TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                expectedDefaultPasswordType: PasswordType.AlphaNumeric,
+                expectedDefaultPasswordLength: 10);
+
+            TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                expectedDefaultPasswordType: PasswordType.Numeric,
+                expectedDefaultPasswordLength: 6);
+        }
+
+        [TestMethod]
+        public void AppSettingsShouldChangeInvalidPasswordTypesToValidPasswordTypes()
+        {
+            // The PasswordType.AnyKeyOnAnEnglishKeyboard is not supported because spaces are not allowed
+            // in passwords created by the GUI version of Generator.
+            TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                expectedDefaultPasswordType: PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace,
+                expectedDefaultPasswordLength: 8,
+                defaultPasswordTypeInConfigurationFile: PasswordType.AnyKeyOnAnEnglishKeyboard);
+        }
+
+        [TestMethod]
+        public void SaveShouldPersistTheSpecifiedSettings()
+        {
+            (AppSettings appSettings, Mock <ITextFileService> textFileServiceMock) = 
+                TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+                    expectedDefaultPasswordType: PasswordType.AlphaNumeric,
+                    expectedDefaultPasswordLength: 10);
+
+            appSettings.Save();
+
+            textFileServiceMock.Verify(
+                tfs => tfs.CreateDirectoryIfItDoesNotExist(It.IsAny<string>()),
+                Times.Once,
+                "The AppSettings class must create the directory which holds the settings file before it writes the settings file.");
+
+            textFileServiceMock.Verify(
+                tfs => tfs.WriteTextFile(
+                    It.IsAny<string>(), 
+                    It.Is<string>(str => IsSettingsFileContentValid(str, PasswordType.AlphaNumeric, 10))),
+                Times.Once,
+                "The AppSettings class must correctly write its current settings.");
+        }
+
+        private static bool IsSettingsFileContentValid(string savedSettingsFileJsonContent, PasswordType expectedPasswordType, int expectedPasswordLength)
+        {
+            Regex matchDefaultPasswordTypeRegEx = CreateJsonPropertyMatcherRegEx(
+                jsonProperyName: "DefaultPasswordType",
+                jsonProperyValue: $"\"{expectedPasswordType}\"");
+
+            Regex matchDefaultPasswordLengthRegEx = CreateJsonPropertyMatcherRegEx(
+                jsonProperyName: "DefaultPasswordLengthInChars",
+                jsonProperyValue: expectedPasswordLength);
+
+            return matchDefaultPasswordTypeRegEx.IsMatch(savedSettingsFileJsonContent) &&
+                   matchDefaultPasswordLengthRegEx.IsMatch(savedSettingsFileJsonContent);
+
+
+
+            static Regex CreateJsonPropertyMatcherRegEx(string jsonProperyName, object jsonProperyValue)
+            {
+                string matchJsonPropetyRegExString = $"\"{jsonProperyName}\":\\s*{jsonProperyValue}";
+                return new Regex(matchJsonPropetyRegExString, RegexOptions.Multiline | RegexOptions.CultureInvariant);
+            }
+        }
+
+        private static (AppSettings, Mock<ITextFileService>) CreateAppSettingsClass(string expectedSettingsFileContent)
+        {
+            Mock<ITextFileService> textFileServiceMock = CreateTextServiceMock(expectedSettingsFileContent);
+            AppSettings newAppSettings = new AppSettings(textFileServiceMock.Object);
+            return (newAppSettings, textFileServiceMock);
+        }
+
+        private static Mock<ITextFileService> CreateTextServiceMock(string expectedTextFileContent)
+        {
+            Mock<ITextFileService> textFileServiceMock = new Mock<ITextFileService>(MockBehavior.Strict);
+
+            ISetup<ITextFileService, bool> textFileServiceMockSetup;
+
+            // TFS stands for Text File Service.
+            textFileServiceMockSetup = textFileServiceMock.Setup(tfs => tfs.TryReadTextFile(It.IsAny<string>(), out expectedTextFileContent));
+
+            if (expectedTextFileContent != null)
+            {
+                textFileServiceMockSetup.Returns(true);
+            }
+            else
+            {
+                textFileServiceMockSetup.Returns(false);
+            }
+
+            textFileServiceMock.Setup(tfs => tfs.CreateDirectoryIfItDoesNotExist(It.IsAny<string>()));
+            textFileServiceMock.Setup(tfs => tfs.WriteTextFile(It.IsAny<string>(), It.IsAny<string>()));
+
+            return textFileServiceMock;
+        }
+
+        private static (AppSettings, Mock<ITextFileService>) TestAppSettingsCorrectlyParsesSettingsInSettingsFile(
+            PasswordType expectedDefaultPasswordType, 
+            int expectedDefaultPasswordLength, 
+            PasswordType? defaultPasswordTypeInConfigurationFile = null)
+        {
+            if (!defaultPasswordTypeInConfigurationFile.HasValue)
+            {
+                defaultPasswordTypeInConfigurationFile = expectedDefaultPasswordType;
+            }
+
+            string settingsFileContent =
+                 "{                                                                                        \n" +
+                $"    \"DefaultPasswordType\": \"{defaultPasswordTypeInConfigurationFile.ToString()}\",    \n" +
+                $"    \"DefaultPasswordLengthInChars\": {expectedDefaultPasswordLength}                    \n" +
+                 "}                                                                                        \n";
+
+            (AppSettings appSettings, Mock<ITextFileService> textFileServiceMock) = CreateAppSettingsClass(settingsFileContent);
+
+            AssertAppSettingsMatchExpectedValues(
+                appSettings,
+                expectedDefaultPasswordType,
+                expectedDefaultPasswordLength);
+
+            return (appSettings, textFileServiceMock);
+        }
+
+        private static void AssertAppSettingsMatchExpectedValues(AppSettings appSettings, PasswordType expectedDefaultPasswordType, int expectedDefaultPasswordLength)
+        {
+            Assert.IsTrue(appSettings.DefaultPasswordType == expectedDefaultPasswordType);
+            Assert.IsTrue(appSettings.DefaultPasswordLengthInChars == expectedDefaultPasswordLength);
+        }
+    }
+}

--- a/EasyToUseGeneratorTests/EasyToUseGeneratorTests.csproj
+++ b/EasyToUseGeneratorTests/EasyToUseGeneratorTests.csproj
@@ -1,24 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-
+    <TargetFramework>net5.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
+    <SignAssembly>false</SignAssembly>
+    <Version>1.2.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\CommonGeneratorCode\CommonGeneratorCode.csproj" />
-    <ProjectReference Include="..\TestUtil\TestUtil.csproj" />
+    <ProjectReference Include="..\EasyToUseGenerator\EasyToUseGenerator.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Generator.sln
+++ b/Generator.sln
@@ -29,7 +29,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{050BD34D
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ProductCode", "ProductCode", "{D9B76D5E-9075-4AF2-802A-E6AEA290C4E3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonGeneratorCodeUnitTests", "CommonGeneratorCodeUnitTests\CommonGeneratorCodeUnitTests.csproj", "{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonGeneratorCodeUnitTests", "CommonGeneratorCodeUnitTests\CommonGeneratorCodeUnitTests.csproj", "{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyToUseGeneratorTests", "EasyToUseGeneratorTests\EasyToUseGeneratorTests.csproj", "{5D651872-18CA-46C2-BA91-72D0DDBEB7FA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,10 @@ Global
 		{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D651872-18CA-46C2-BA91-72D0DDBEB7FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D651872-18CA-46C2-BA91-72D0DDBEB7FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D651872-18CA-46C2-BA91-72D0DDBEB7FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D651872-18CA-46C2-BA91-72D0DDBEB7FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,6 +88,7 @@ Global
 		{9070C6E0-1A41-4EF7-AE88-55A745BC243A} = {D9B76D5E-9075-4AF2-802A-E6AEA290C4E3}
 		{B4D68CDC-DD3D-476C-A855-EE387568AA32} = {D9B76D5E-9075-4AF2-802A-E6AEA290C4E3}
 		{ADC00CB9-14C0-4EA7-BACC-7BD64E5836CB} = {050BD34D-2BB0-49AE-B895-3FC8650BDAB9}
+		{5D651872-18CA-46C2-BA91-72D0DDBEB7FA} = {050BD34D-2BB0-49AE-B895-3FC8650BDAB9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0888D024-AE6D-4472-8511-9EB931360D9C}

--- a/Generator/GeneratePasswordCommand.cs
+++ b/Generator/GeneratePasswordCommand.cs
@@ -80,7 +80,7 @@ namespace Generator
                     e);
             }
 
-            if (passwordLengthInCharacters is < Constants.MinimumPasswordLengthInChars or > Constants.MaximumPasswordLengthInChars)
+            if (!Password.IsValidPasswordLength(passwordLengthInCharacters))
             {
                 throw new InvalidCommandLineArgumentException(
                     CommonErrorMessages.PasswordLengthOutOfRangeFormatString,

--- a/GeneratorUnitTest/GeneratorUnitTest.csproj
+++ b/GeneratorUnitTest/GeneratorUnitTest.csproj
@@ -27,9 +27,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GenericCommandLineArgumentParser/Command.cs
+++ b/GenericCommandLineArgumentParser/Command.cs
@@ -48,9 +48,9 @@ namespace GenericCommandLineArgumentParser
             MaxNumberOfArguments = maxNumberOfArguments;
         }
 
-        public uint MinNumberOfArguments { get; private set; }
+        public uint MinNumberOfArguments { get; private init; }
 
-        public uint MaxNumberOfArguments { get; private set; }
+        public uint MaxNumberOfArguments { get; private init; }
 
         public bool IsName(string commandNameWithoutPrefex)
         {

--- a/GenericCommandLineArgumentParserUnitTests/GenericCommandLineArgumentParserUnitTests.csproj
+++ b/GenericCommandLineArgumentParserUnitTests/GenericCommandLineArgumentParserUnitTests.csproj
@@ -27,9 +27,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestUtil/TestUtil.csproj
+++ b/TestUtil/TestUtil.csproj
@@ -29,9 +29,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Completes Issue #13  

# Major changes
Now users can change the default password type (any key on a keyboard, alpha numeric or numeric) and default password length.  This setting changes the password which is created when the program starts.  It also changes the defaults in the Create New Password dialog box.

# Minor changes
- Settings are saved in a JSON file called "$env:AppData\Generator\GeneratorSettings.json" (Power Shell syntax).  Each user has a separate configuration file.
- Added a dependency injection mechanism.  For more information, please see the ServiceFactory class.
- Added unit tests for the code which can be unit tested
- Update unit test dependencies and added a dependency on the MOQ mocking framework.
