### PR TITLE
Added an easy-to-use password strength indicator

### DIFF
--- a/CommonGeneratorCode/CommonUserInterface.Designer.cs
+++ b/CommonGeneratorCode/CommonUserInterface.Designer.cs
@@ -19,7 +19,7 @@ namespace CommonGeneratorCode {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class CommonUserInterface {
@@ -61,6 +61,33 @@ namespace CommonGeneratorCode {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Acceptable for PINs.
+        /// </summary>
+        public static string AcceptableOnlyForPins {
+            get {
+                return ResourceManager.GetString("AcceptableOnlyForPins", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This password should only be used for PINs and other passwords where the number of guesses can be severely limited.  In general, if more than 10 guesses can be made, this type of password should not be used.  Examples of devices which severely limit the number of guesses include cell phone lock screens, ATM cards, USB security keys (ex. YubiKey) and smart cards.  If you are not sure if you should use this type of password, do not use it..
+        /// </summary>
+        public static string AcceptableOnlyForPinsDescription {
+            get {
+                return ResourceManager.GetString("AcceptableOnlyForPinsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Acceptable.
+        /// </summary>
+        public static string AcceptablePassword {
+            get {
+                return ResourceManager.GetString("AcceptablePassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This password provides adequate security.  It cannot be guessed unless a computer or website does not limit the number of password attempts and the attacker spends a lot of time and money trying to guess it.  It may also be guessable if an attacker compromises a computer or website and steals the password database..
         /// </summary>
         public static string AcceptablePasswordDescription {
@@ -70,7 +97,16 @@ namespace CommonGeneratorCode {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This password can be used to protect any data becausse it cannot be guessed..
+        ///   Looks up a localized string similar to Strong.
+        /// </summary>
+        public static string StrongPassword {
+            get {
+                return ResourceManager.GetString("StrongPassword", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This password can be used to protect any data because it cannot be guessed..
         /// </summary>
         public static string StrongPasswordDescription {
             get {
@@ -79,7 +115,16 @@ namespace CommonGeneratorCode {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This password should only be used for PINs and other passwords where the number of guesses can be severely limited.  In general, if more than 10 guesses can be made, this type of password should not be used.  Examples of devices which severely limit the number of guesses include cell phones, ATM cards, USB Security Keys (ex. YubiKey) and smart cards.  If you are not sure if you should use this type of password, do not use it..
+        ///   Looks up a localized string similar to Weak.
+        /// </summary>
+        public static string Weak {
+            get {
+                return ResourceManager.GetString("Weak", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This password should not be used because it is insecure.  It&apos;s insecure because it is too short and an attacker can easily guess it by trying every possible password value..
         /// </summary>
         public static string WeakPasswordDescription {
             get {

--- a/CommonGeneratorCode/CommonUserInterface.resx
+++ b/CommonGeneratorCode/CommonUserInterface.resx
@@ -117,13 +117,28 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AcceptableOnlyForPins" xml:space="preserve">
+    <value>Acceptable for PINs</value>
+  </data>
+  <data name="AcceptableOnlyForPinsDescription" xml:space="preserve">
+    <value>This password should only be used for PINs and other passwords where the number of guesses can be severely limited.  In general, if more than 10 guesses can be made, this type of password should not be used.  Examples of devices which severely limit the number of guesses include cell phone lock screens, ATM cards, USB security keys (ex. YubiKey) and smart cards.  If you are not sure if you should use this type of password, do not use it.</value>
+  </data>
+  <data name="AcceptablePassword" xml:space="preserve">
+    <value>Acceptable</value>
+  </data>
   <data name="AcceptablePasswordDescription" xml:space="preserve">
     <value>This password provides adequate security.  It cannot be guessed unless a computer or website does not limit the number of password attempts and the attacker spends a lot of time and money trying to guess it.  It may also be guessable if an attacker compromises a computer or website and steals the password database.</value>
+  </data>
+  <data name="StrongPassword" xml:space="preserve">
+    <value>Strong</value>
   </data>
   <data name="StrongPasswordDescription" xml:space="preserve">
     <value>This password can be used to protect any data because it cannot be guessed.</value>
   </data>
+  <data name="Weak" xml:space="preserve">
+    <value>Weak</value>
+  </data>
   <data name="WeakPasswordDescription" xml:space="preserve">
-    <value>This password should only be used for PINs and other passwords where the number of guesses can be severely limited.  In general, if more than 10 guesses can be made, this type of password should not be used.  Examples of devices which severely limit the number of guesses include cell phone lock screens, ATM cards, USB security keys (ex. YubiKey) and smart cards.  If you are not sure if you should use this type of password, do not use it.</value>
+    <value>This password should not be used because it is insecure.  It's insecure because it is too short and an attacker can easily guess it by trying every possible password value.</value>
   </data>
 </root>

--- a/CommonGeneratorCodeUnitTests/CommonGeneratorCodeUnitTests.csproj
+++ b/CommonGeneratorCodeUnitTests/CommonGeneratorCodeUnitTests.csproj
@@ -25,9 +25,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommonGeneratorCodeUnitTests/PasswordUnitTests.cs
+++ b/CommonGeneratorCodeUnitTests/PasswordUnitTests.cs
@@ -211,8 +211,7 @@ namespace CommonGeneratorCodeUnitTests
             return (character == ' ');
         }
 
-        [TestMethod]
-        public void VerifyEachPasswordTypeReturnsADifferentPropertyValue(Func<Password, string> getProperty)
+        private static  void VerifyEachPasswordTypeReturnsADifferentPropertyValue(Func<Password, string> getProperty)
         {
             Password[] differentStrengthPasswords = new[]
             {

--- a/EasyToUseGenerator/HelpWindow.xaml
+++ b/EasyToUseGenerator/HelpWindow.xaml
@@ -9,7 +9,7 @@
                       Style="{StaticResource StandardWindowStyle}"
                       
                       WindowStartupLocation="CenterOwner"
-                      TitleBarBackground="DarkSlateGray"
+                      TitleBarBackground="Black"
                                             
                       Height="290" 
                       Width="398">

--- a/EasyToUseGenerator/MainWindow.xaml
+++ b/EasyToUseGenerator/MainWindow.xaml
@@ -35,11 +35,10 @@
         Style="{StaticResource StandardWindowStyle}"
                       
         Width="570"
-        Height="255">
+        Height="301">
 
     <StackPanel x:Name="mainWindowContentStackPanel"
                 Style="{StaticResource StandardMainStackPanelStyle}">
-        <!-- TODO - Make Localizable -->
         <Label Content="Newly Created Password"
                Target="{Binding ElementName=newlyCreatedPasswordTextBox}"   
                
@@ -55,15 +54,27 @@
                  FontSize="24"
                  BorderThickness="0"/>
 
-        <!-- TODO - Make Localizable -->
-        <Label Content="Password Strength"
+        <Label Content="{x:Static resources:UserInterface.PasswordStrengthLabel}"
                Target="{Binding ElementName=passwordStrengthTextBlock}"   
                
                Style="{StaticResource StandardLabelStyle}"
                Margin="0,10,0,0"/>
         
         <TextBlock x:Name="passwordStrengthTextBlock"
-                   Text="{Binding Path=PasswordStrengthTextDescription, Mode=OneWay}"
+                   Text="{Binding Path=PasswordStrength, Mode=OneWay}"
+                               
+                   TextWrapping="Wrap"
+                   
+                   Margin="{StaticResource StandardVerticalSpaceBetweenItemsMargin}"/>
+
+        <Label Content="{x:Static resources:UserInterface.PasswordStrengthDescriptionLabel}"
+               Target="{Binding ElementName=passwordStrengthDescriptionTextBlock}"   
+               
+               Style="{StaticResource StandardLabelStyle}"
+               Margin="0,10,0,0"/>
+
+        <TextBlock x:Name="passwordStrengthDescriptionTextBlock"
+                   Text="{Binding Path=PasswordStrengthDescription, Mode=OneWay}"
                                
                    TextWrapping="Wrap"
                    

--- a/EasyToUseGenerator/MainWindow.xaml
+++ b/EasyToUseGenerator/MainWindow.xaml
@@ -85,7 +85,7 @@
                     Margin="0,10,0,0">
             
             <Button x:Name="copyToClipBoardButton"
-                    Content="Copy to Clipboard"
+                    Content="{x:Static resources:UserInterface.CopyToClipboardButtonText}"
                     Click="OnCopyToClipBoardPressed"
                     
                     IsDefault="True"
@@ -94,7 +94,7 @@
                     Style="{StaticResource StandardButtonStyle}"/>
 
             <Button x:Name="createNewPasswordButton"
-                    Content="Create New Password"
+                    Content="{x:Static resources:UserInterface.CreateNewPasswordButtonText}"
                     Click="OnCreateNewPasswordClicked"
                     
                     TabIndex="1"
@@ -104,7 +104,7 @@
                     Margin="5,0,0,0"/>
 
             <Button x:Name="helpButton"
-                    Content="Help"                    
+                    Content="{x:Static resources:UserInterface.HelpButtonText}"                    
                     Click="OnHelpClicked"
                     
                     TabIndex="2"

--- a/EasyToUseGenerator/MainWindow.xaml.cs
+++ b/EasyToUseGenerator/MainWindow.xaml.cs
@@ -41,7 +41,8 @@ namespace EasyToUseGenerator
         }
 
         public string NewlyCreatedPassword => this.currentPassword.Value;
-        public string PasswordStrengthTextDescription => this.currentPassword.StrengthDescription;
+        public string PasswordStrength => this.currentPassword.StrengthDisplayText;
+        public string PasswordStrengthDescription => this.currentPassword.StrengthDescription;
 
         private void OnCopyToClipBoardPressed(object sender, RoutedEventArgs e)
         {
@@ -59,7 +60,8 @@ namespace EasyToUseGenerator
                     createNewPasswordWindow.NewPasswordType,
                     createNewPasswordWindow.NewPasswordLengthInChars);
                 this.NotifyPropertyChanged(nameof(this.NewlyCreatedPassword));
-                this.NotifyPropertyChanged(nameof(this.PasswordStrengthTextDescription));
+                this.NotifyPropertyChanged(nameof(this.PasswordStrength));
+                this.NotifyPropertyChanged(nameof(this.PasswordStrengthDescription));
             }
         }
 

--- a/EasyToUseGenerator/Resources/UserInterface.Designer.cs
+++ b/EasyToUseGenerator/Resources/UserInterface.Designer.cs
@@ -61,6 +61,24 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Copy to Clipboard.
+        /// </summary>
+        public static string CopyToClipboardButtonText {
+            get {
+                return ResourceManager.GetString("CopyToClipboardButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Create New Password.
+        /// </summary>
+        public static string CreateNewPasswordButtonText {
+            get {
+                return ResourceManager.GetString("CreateNewPasswordButtonText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Documentation.
         /// </summary>
         public static string DocumentationButtonText {
@@ -84,6 +102,15 @@ namespace EasyToUseGenerator.Resources {
         public static string GeneratorNameAndVersionFormatString {
             get {
                 return ResourceManager.GetString("GeneratorNameAndVersionFormatString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Help.
+        /// </summary>
+        public static string HelpButtonText {
+            get {
+                return ResourceManager.GetString("HelpButtonText", resourceCulture);
             }
         }
         

--- a/EasyToUseGenerator/Resources/UserInterface.Designer.cs
+++ b/EasyToUseGenerator/Resources/UserInterface.Designer.cs
@@ -124,6 +124,24 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Password Strength Description.
+        /// </summary>
+        public static string PasswordStrengthDescriptionLabel {
+            get {
+                return ResourceManager.GetString("PasswordStrengthDescriptionLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password Strength.
+        /// </summary>
+        public static string PasswordStrengthLabel {
+            get {
+                return ResourceManager.GetString("PasswordStrengthLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project Website.
         /// </summary>
         public static string ProjectWebSiteButtonText {

--- a/EasyToUseGenerator/Resources/UserInterface.resx
+++ b/EasyToUseGenerator/Resources/UserInterface.resx
@@ -117,6 +117,14 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CopyToClipboardButtonText" xml:space="preserve">
+    <value>Copy to Clipboard</value>
+    <comment>Used on the Main Window</comment>
+  </data>
+  <data name="CreateNewPasswordButtonText" xml:space="preserve">
+    <value>Create New Password</value>
+    <comment>Used on the Main Window</comment>
+  </data>
   <data name="DocumentationButtonText" xml:space="preserve">
     <value>Documentation</value>
     <comment>Used on the Help Window</comment>
@@ -128,6 +136,10 @@
   <data name="GeneratorNameAndVersionFormatString" xml:space="preserve">
     <value>Generator {0}.{1}.{2}</value>
     <comment>Used on the Help Window - {0} = Major Version Number, {1} = Minor Version Number, {2} = Revision Number</comment>
+  </data>
+  <data name="HelpButtonText" xml:space="preserve">
+    <value>Help</value>
+    <comment>Used on the Main Window</comment>
   </data>
   <data name="HelpWindowTitle" xml:space="preserve">
     <value>Generator Help</value>

--- a/EasyToUseGenerator/Resources/UserInterface.resx
+++ b/EasyToUseGenerator/Resources/UserInterface.resx
@@ -119,30 +119,45 @@
   </resheader>
   <data name="DocumentationButtonText" xml:space="preserve">
     <value>Documentation</value>
+    <comment>Used on the Help Window</comment>
   </data>
   <data name="DownloadReleaseButtonText" xml:space="preserve">
     <value>Download Release</value>
+    <comment>Used on the Help Window</comment>
   </data>
   <data name="GeneratorNameAndVersionFormatString" xml:space="preserve">
     <value>Generator {0}.{1}.{2}</value>
-    <comment>{0} = Major Version Number, {1} = Minor Version Number, {2} = Revision Number</comment>
+    <comment>Used on the Help Window - {0} = Major Version Number, {1} = Minor Version Number, {2} = Revision Number</comment>
   </data>
   <data name="HelpWindowTitle" xml:space="preserve">
     <value>Generator Help</value>
+    <comment>Used on the Help Window</comment>
   </data>
   <data name="MainWindowTitle" xml:space="preserve">
     <value>Generator</value>
+    <comment>Used on the Main Window</comment>
   </data>
   <data name="OKButtonText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="PasswordAdviceButtonText" xml:space="preserve">
     <value>Password Advice</value>
+    <comment>Used on the Help Window</comment>
+  </data>
+  <data name="PasswordStrengthDescriptionLabel" xml:space="preserve">
+    <value>Password Strength Description</value>
+    <comment>Used on the Main Window</comment>
+  </data>
+  <data name="PasswordStrengthLabel" xml:space="preserve">
+    <value>Password Strength</value>
+    <comment>Used on the Main Window</comment>
   </data>
   <data name="ProjectWebSiteButtonText" xml:space="preserve">
     <value>Project Website</value>
+    <comment>Used on the Help Window</comment>
   </data>
   <data name="ReportProblemsButtonText" xml:space="preserve">
     <value>Report Problems or Give Feedback</value>
+    <comment>Used on the Help Window</comment>
   </data>
 </root>

--- a/EasyToUseGeneratorTests/EasyToUseGeneratorTests.csproj
+++ b/EasyToUseGeneratorTests/EasyToUseGeneratorTests.csproj
@@ -21,10 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Moq" Version="4.18.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GeneratorUnitTest/GeneratorUnitTest.csproj
+++ b/GeneratorUnitTest/GeneratorUnitTest.csproj
@@ -33,9 +33,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GenericCommandLineArgumentParserUnitTests/GenericCommandLineArgumentParserUnitTests.csproj
+++ b/GenericCommandLineArgumentParserUnitTests/GenericCommandLineArgumentParserUnitTests.csproj
@@ -33,9 +33,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TestUtil/TestUtil.csproj
+++ b/TestUtil/TestUtil.csproj
@@ -34,9 +34,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Added an easy-to-use password strength indicator to the Main Window.  Basically, it says a password is Strong, Acceptable, Acceptable for PINs or Weak.

- Moved some hard coded strings from a XAML file to a resource file.  This makes it easier to localize this program.

- Changed the color of the Help Window's caption text from dark grew to black.  I think black looks better.

- Updated the packages to the latest versions