### PR TITLE
Fixed accessibility bugs (UI Automation / Windows Narrator), keybaord…

### DIFF
--- a/CommonGeneratorCode/Password.cs
+++ b/CommonGeneratorCode/Password.cs
@@ -123,13 +123,17 @@ namespace CommonGeneratorCode
             {
                 throw new ArgumentException(CommonErrorMessages.PasswordLengthTooLong);
             }
-            
-            IReadOnlyList<char> charactersWhichCanBeInPassword = GetCharactersWhichCanBeInPasswordList(passwordType);
+
+            this.PasswordType = passwordType;
+
+            IReadOnlyList<char> charactersWhichCanBeInPassword = GetCharactersWhichCanBeInPasswordList(this.PasswordType);
             this.Value = GeneratePassword(charactersWhichCanBeInPassword, passwordLengthInCharacters);
             (this.Strength, this.StrengthInBits) = DeterminePasswordStrength(
-                charactersWhichCanBeInPassword.Count, 
+                charactersWhichCanBeInPassword.Count,
                 passwordLengthInCharacters);
         }
+
+        public PasswordType PasswordType { get; }
 
         public string Value { get; private set; }
 

--- a/CommonGeneratorCodeUnitTests/PasswordUnitTests.cs
+++ b/CommonGeneratorCodeUnitTests/PasswordUnitTests.cs
@@ -83,6 +83,8 @@ namespace CommonGeneratorCodeUnitTests
         {
             Password password = new Password(passwordType, passwordLengthInChars);
 
+            Assert.IsTrue(password.PasswordType == passwordType, "The password's type should match the value passed to Password's constructor.");
+
             Assert.IsTrue(password.Value.Length == passwordLengthInChars, "The password's length should match the length the user requested.");
             Assert.AreEqual(expectedStrength, actual: password.Strength);
 

--- a/EasyToUseGenerator/App.xaml
+++ b/EasyToUseGenerator/App.xaml
@@ -27,6 +27,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:system="clr-namespace:System;assembly=mscorlib"
              xmlns:local="clr-namespace:EasyToUseGenerator"             
+             xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
              
              StartupUri="MainWindow.xaml"
              
@@ -372,6 +373,7 @@
             
             <Setter Property="WindowChrome.IsHitTestVisibleInChrome" Value="True"/>
             <Setter Property="IsTabStop" Value="False"/>
+            <Setter Property="Focusable" Value="False"/>
 
             <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
 
@@ -414,7 +416,7 @@
                             <!-- Column 0 - Window Title column -->
                             <ColumnDefinition Width="Auto"/>
 
-                            <!-- Column 1 - Minizine button column -->
+                            <!-- Column 1 - Minimize button column -->
                             <ColumnDefinition/>
 
                             <!-- 
@@ -441,6 +443,8 @@
                         <Button Name="MinimizeButton"
                                 Content="&#xE921;"
                                 
+                                AutomationProperties.Name="{x:Static resources:UserInterface.MinimizeWindowButtonUIAutomationName}"
+                                
                                 Grid.Row="0"
                                 Grid.Column="1"
                                 
@@ -450,6 +454,9 @@
 
                         <Button Name="CloseButton"
                                 Content="&#xE8BB;"
+    
+                                AutomationProperties.AcceleratorKey="{x:Static resources:UserInterface.CloseWindowButtonUIAutomationAcceleratorKey}"
+                                AutomationProperties.Name="{x:Static resources:UserInterface.CloseWindowButtonUIAutomationName}"
 
                                 Grid.Row="0"
                                 Grid.Column="2"
@@ -475,6 +482,7 @@
             <Setter Property="Template" Value="{StaticResource StandardWindowControlTemplate}"/>
             <Setter Property="Background" Value="White"/>
             <Setter Property="ResizeMode" Value="NoResize"/>
+            <Setter Property="Focusable" Value="False"/>
 
             <Setter Property="WindowChrome.WindowChrome">
                 <Setter.Value>

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -63,33 +63,36 @@
             <RadioButton Content="{x:Static resources:UserInterface.AnyCharacterWhichCanBeTypedRadioButtonText}"
                          ToolTip="{x:Static resources:UserInterface.AnyCharacterWhichCanBeTypedRadioButtonToolTipText}"
                          IsChecked="{Binding IsAnyKeyWhichCanBeTypedRadioButtonChecked, Mode=OneTime}"
-                         Click="OnAnyKeyWhichCanBeTypedRadioButtonClicked"
+                         Checked="OnAnyKeyWhichCanBeTypedRadioButtonChecked"
                          
-                         Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
+                           Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
 
             <RadioButton Content="{x:Static resources:UserInterface.LettersAndNumbersRadioButtonText}"
                          ToolTip="{x:Static resources:UserInterface.LettersAndNumbersRadioButtonToolTipText}"
                          IsChecked="{Binding IsLettersAndNumbersRadioButtonChecked, Mode=OneTime}"
-                         Click="OnLettersAndNumbersRadioButtonClicked"
+                         Checked="OnLettersAndNumbersRadioButtonChecked"
                          
                          Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
 
             <RadioButton Content="{x:Static resources:UserInterface.NumbersRadioButtonText}"
                          ToolTip="{x:Static resources:UserInterface.NumbersRadioButtonToolTipText}"
-                         Click="OnNumbersRadioButtonClicked"
+                         Checked="OnNumbersRadioButtonChecked"
                          IsChecked="{Binding IsNumbersRadioButtonChecked, Mode=OneTime}"
                          
                          Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
         </StackPanel>
 
-        <Label Content="{x:Static resources:UserInterface.NewPasswordLengthLabel}"
+        <Label x:Name="newPasswordLengthLabel"
+               Content="{x:Static resources:UserInterface.NewPasswordLengthLabel}"
                Target="{Binding ElementName=passwordLengthTextBox}"
                Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"
                Style="{StaticResource StandardLabelStyle}"/>
         
-        <!-- The max text length is 2 because a password can only contain 1 to 38 characters. -->
+        <!-- The max text length is 10 because it makes it easier to edit numbers. Valid password lengths are between 1 and 38 characters. -->
         <TextBox x:Name="passwordLengthTextBox"
-                 MaxLength="2"
+                 AutomationProperties.LabeledBy="{Binding ElementName=newPasswordLengthLabel}"
+                                  
+                 MaxLength="10"
                  MaxLines="1"   
                  
                  HorizontalAlignment="Left"

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml.cs
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml.cs
@@ -108,17 +108,17 @@ namespace EasyToUseGenerator
             get => this.NewPasswordType == PasswordType.Numeric;
         }
 
-        private void OnAnyKeyWhichCanBeTypedRadioButtonClicked(object sender, RoutedEventArgs e)
+        private void OnAnyKeyWhichCanBeTypedRadioButtonChecked(object sender, RoutedEventArgs e)
         {
             this.NewPasswordType = PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace;
         }
 
-        private void OnLettersAndNumbersRadioButtonClicked(object sender, RoutedEventArgs e)
+        private void OnLettersAndNumbersRadioButtonChecked(object sender, RoutedEventArgs e)
         {
             this.NewPasswordType = PasswordType.AlphaNumeric;
         }
 
-        private void OnNumbersRadioButtonClicked(object sender, RoutedEventArgs e)
+        private void OnNumbersRadioButtonChecked(object sender, RoutedEventArgs e)
         {
             this.NewPasswordType = PasswordType.Numeric;
         }

--- a/EasyToUseGenerator/HelpWindow.xaml
+++ b/EasyToUseGenerator/HelpWindow.xaml
@@ -59,15 +59,11 @@
     </local:StandardWindow.Resources>
     
     <StackPanel Style="{StaticResource StandardMainStackPanelStyle}">
-        <TextBox Text="{Binding Path=GeneratorNameAndVersion, Mode=OneTime}"
-                 IsReadOnly="True"
+        <TextBlock Text="{Binding Path=GeneratorNameAndVersion, Mode=OneTime}"
+                   Foreground="Black"
+                   FontSize="24"
                  
-                 Foreground="Black"
-                 FontSize="24"
-                 
-                 TextAlignment="Center"
-                 
-                 BorderThickness="0"/>
+                   TextAlignment="Center"/>
 
         <Button Content="{x:Static resources:UserInterface.DocumentationButtonText}"
                 Click="OnDocumentationClicked"

--- a/EasyToUseGenerator/MainWindow.xaml
+++ b/EasyToUseGenerator/MainWindow.xaml
@@ -37,44 +37,35 @@
         Width="570"
         Height="301">
 
-    <StackPanel x:Name="mainWindowContentStackPanel"
-                Style="{StaticResource StandardMainStackPanelStyle}">
-        <Label Content="Newly Created Password"
-               Target="{Binding ElementName=newlyCreatedPasswordTextBox}"   
-               
+    <StackPanel Style="{StaticResource StandardMainStackPanelStyle}">
+        <Label Content="{x:Static resources:UserInterface.NewlyCreatedPasswordLabel}"
+
                Style="{StaticResource StandardLabelStyle}"/>
         
-        <TextBox x:Name="newlyCreatedPasswordTextBox"
-                 Text="{Binding Path=NewlyCreatedPassword, Mode=OneWay}"
-                    
-                 Focusable="False"
-                 IsReadOnly="True"
-                         
-                 FontFamily="Courier New"
-                 FontSize="24"
-                 BorderThickness="0"/>
+        <TextBlock Text="{Binding Path=NewlyCreatedPassword, Mode=OneWay}"
+               
+                   AutomationProperties.HelpText="{Binding Path=NewlyCreatedPasswordUIAutomationHelpText, Mode=OneWay}"
+                   
+                   FontFamily="Courier New"
+                   FontSize="24"/>
 
         <Label Content="{x:Static resources:UserInterface.PasswordStrengthLabel}"
-               Target="{Binding ElementName=passwordStrengthTextBlock}"   
-               
+              
                Style="{StaticResource StandardLabelStyle}"
                Margin="0,10,0,0"/>
         
-        <TextBlock x:Name="passwordStrengthTextBlock"
-                   Text="{Binding Path=PasswordStrength, Mode=OneWay}"
+        <TextBlock Text="{Binding Path=PasswordStrength, Mode=OneWay}"
                                
                    TextWrapping="Wrap"
                    
                    Margin="{StaticResource StandardVerticalSpaceBetweenItemsMargin}"/>
 
         <Label Content="{x:Static resources:UserInterface.PasswordStrengthDescriptionLabel}"
-               Target="{Binding ElementName=passwordStrengthDescriptionTextBlock}"   
                
                Style="{StaticResource StandardLabelStyle}"
                Margin="0,10,0,0"/>
 
-        <TextBlock x:Name="passwordStrengthDescriptionTextBlock"
-                   Text="{Binding Path=PasswordStrengthDescription, Mode=OneWay}"
+        <TextBlock Text="{Binding Path=PasswordStrengthDescription, Mode=OneWay}"
                                
                    TextWrapping="Wrap"
                    
@@ -84,8 +75,7 @@
         <StackPanel Orientation="Horizontal"
                     Margin="0,10,0,0">
             
-            <Button x:Name="copyToClipBoardButton"
-                    Content="{x:Static resources:UserInterface.CopyToClipboardButtonText}"
+            <Button Content="{x:Static resources:UserInterface.CopyToClipboardButtonText}"
                     Click="OnCopyToClipBoardPressed"
                     
                     IsDefault="True"
@@ -93,8 +83,7 @@
                     
                     Style="{StaticResource StandardButtonStyle}"/>
 
-            <Button x:Name="createNewPasswordButton"
-                    Content="{x:Static resources:UserInterface.CreateNewPasswordButtonText}"
+            <Button Content="{x:Static resources:UserInterface.CreateNewPasswordButtonText}"
                     Click="OnCreateNewPasswordClicked"
                     
                     TabIndex="1"
@@ -103,8 +92,7 @@
                     
                     Margin="5,0,0,0"/>
 
-            <Button x:Name="helpButton"
-                    Content="{x:Static resources:UserInterface.HelpButtonText}"
+            <Button Content="{x:Static resources:UserInterface.HelpButtonText}"
                     Click="OnHelpClicked"
                     
                     TabIndex="2"

--- a/EasyToUseGenerator/MainWindow.xaml.cs
+++ b/EasyToUseGenerator/MainWindow.xaml.cs
@@ -23,6 +23,8 @@
 //
 
 using CommonGeneratorCode;
+using EasyToUseGenerator.Resources;
+using System;
 using System.Windows;
 
 namespace EasyToUseGenerator
@@ -41,6 +43,23 @@ namespace EasyToUseGenerator
         }
 
         public string NewlyCreatedPassword => this.currentPassword.Value;
+
+        public string NewlyCreatedPasswordUIAutomationHelpText
+        {
+            get
+            {
+                return this.currentPassword.PasswordType switch
+                {
+                    PasswordType.AnyKeyOnAnEnglishKeyboardExceptASpace => UserInterface.NewlyCreatedAllCharacterPasswordHelpText,
+                    PasswordType.AlphaNumeric => UserInterface.NewlyCreatedAlphaNumericPasswordHelpText,
+                    PasswordType.Numeric => string.Empty,
+
+                    // Passwords with spaces are not supported by this application.
+                    PasswordType.AnyKeyOnAnEnglishKeyboard => throw new Exception(CommonErrorMessages.ThisCaseShouldNeverOccur),
+                    _ => throw new Exception(CommonErrorMessages.ThisCaseShouldNeverOccur),
+                };
+            }
+        }
         public string PasswordStrength => this.currentPassword.StrengthDisplayText;
         public string PasswordStrengthDescription => this.currentPassword.StrengthDescription;
 
@@ -60,6 +79,7 @@ namespace EasyToUseGenerator
                     createNewPasswordWindow.NewPasswordType,
                     createNewPasswordWindow.NewPasswordLengthInChars);
                 this.NotifyPropertyChanged(nameof(this.NewlyCreatedPassword));
+                this.NotifyPropertyChanged(nameof(this.NewlyCreatedPasswordUIAutomationHelpText));
                 this.NotifyPropertyChanged(nameof(this.PasswordStrength));
                 this.NotifyPropertyChanged(nameof(this.PasswordStrengthDescription));
             }

--- a/EasyToUseGenerator/Resources/UserInterface.Designer.cs
+++ b/EasyToUseGenerator/Resources/UserInterface.Designer.cs
@@ -223,7 +223,7 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Also, your password contains symbols (characters which are not letters or numbers) and your screen reader may not read the symbols by default.  Please configure it to read the symbols if you want to hear the entire password.  Note that character case is important because it makes passwords [rest of string was truncated]&quot;;.
+        ///   Looks up a localized string similar to The newly created password may contain lower-case letters, upper-case letters and symbols.  By default, some screen readers do not distinguish between character case and do not read every symbol.  If you want to hear the entire password, you may need to use a feature which reads all characters and each letter’s case.  Note that character case is important because it improves the password’s security.  All of the characters and symbols in a generated password should be used because it makes the password more  [rest of string was truncated]&quot;;.
         /// </summary>
         public static string NewlyCreatedAllCharacterPasswordHelpText {
             get {
@@ -232,7 +232,7 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Note using lower-case and upper-case characters in a password makes the password much more secure.  .
+        ///   Looks up a localized string similar to The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Note using lower-case and upper-case characters in a password makes the password much more secure..
         /// </summary>
         public static string NewlyCreatedAlphaNumericPasswordHelpText {
             get {

--- a/EasyToUseGenerator/Resources/UserInterface.Designer.cs
+++ b/EasyToUseGenerator/Resources/UserInterface.Designer.cs
@@ -88,7 +88,25 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy to Clipboard.
+        ///   Looks up a localized string similar to ALT+F4.
+        /// </summary>
+        public static string CloseWindowButtonUIAutomationAcceleratorKey {
+            get {
+                return ResourceManager.GetString("CloseWindowButtonUIAutomationAcceleratorKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        public static string CloseWindowButtonUIAutomationName {
+            get {
+                return ResourceManager.GetString("CloseWindowButtonUIAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to _Copy to Clipboard.
         /// </summary>
         public static string CopyToClipboardButtonText {
             get {
@@ -97,7 +115,7 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create New Password.
+        ///   Looks up a localized string similar to C_reate New Password.
         /// </summary>
         public static string CreateNewPasswordButtonText {
             get {
@@ -115,7 +133,7 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Create Password.
+        ///   Looks up a localized string similar to _Create Password.
         /// </summary>
         public static string CreatePasswordButtonText {
             get {
@@ -151,7 +169,7 @@ namespace EasyToUseGenerator.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Help.
+        ///   Looks up a localized string similar to _Help.
         /// </summary>
         public static string HelpButtonText {
             get {
@@ -192,6 +210,42 @@ namespace EasyToUseGenerator.Resources {
         public static string MainWindowTitle {
             get {
                 return ResourceManager.GetString("MainWindowTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Minimize.
+        /// </summary>
+        public static string MinimizeWindowButtonUIAutomationName {
+            get {
+                return ResourceManager.GetString("MinimizeWindowButtonUIAutomationName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Also, your password contains symbols (characters which are not letters or numbers) and your screen reader may not read the symbols by default.  Please configure it to read the symbols if you want to hear the entire password.  Note that character case is important because it makes passwords [rest of string was truncated]&quot;;.
+        /// </summary>
+        public static string NewlyCreatedAllCharacterPasswordHelpText {
+            get {
+                return ResourceManager.GetString("NewlyCreatedAllCharacterPasswordHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Note using lower-case and upper-case characters in a password makes the password much more secure.  .
+        /// </summary>
+        public static string NewlyCreatedAlphaNumericPasswordHelpText {
+            get {
+                return ResourceManager.GetString("NewlyCreatedAlphaNumericPasswordHelpText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Newly Created Password.
+        /// </summary>
+        public static string NewlyCreatedPasswordLabel {
+            get {
+                return ResourceManager.GetString("NewlyCreatedPasswordLabel", resourceCulture);
             }
         }
         

--- a/EasyToUseGenerator/Resources/UserInterface.resx
+++ b/EasyToUseGenerator/Resources/UserInterface.resx
@@ -128,12 +128,18 @@
   <data name="CancelButtonText" xml:space="preserve">
     <value>Cancel</value>
   </data>
+  <data name="CloseWindowButtonUIAutomationAcceleratorKey" xml:space="preserve">
+    <value>ALT+F4</value>
+  </data>
+  <data name="CloseWindowButtonUIAutomationName" xml:space="preserve">
+    <value>Close</value>
+  </data>
   <data name="CopyToClipboardButtonText" xml:space="preserve">
-    <value>Copy to Clipboard</value>
+    <value>_Copy to Clipboard</value>
     <comment>Used on the Main Window</comment>
   </data>
   <data name="CreateNewPasswordButtonText" xml:space="preserve">
-    <value>Create New Password</value>
+    <value>C_reate New Password</value>
     <comment>Used on the Main Window</comment>
   </data>
   <data name="CreateNewPasswordWindowTitle" xml:space="preserve">
@@ -141,7 +147,7 @@
     <comment>Used on the Create New Password Window</comment>
   </data>
   <data name="CreatePasswordButtonText" xml:space="preserve">
-    <value>Create Password</value>
+    <value>_Create Password</value>
     <comment>Used on the Create New Password Window</comment>
   </data>
   <data name="DocumentationButtonText" xml:space="preserve">
@@ -157,7 +163,7 @@
     <comment>Used on the Help Window - {0} = Major Version Number, {1} = Minor Version Number, {2} = Revision Number</comment>
   </data>
   <data name="HelpButtonText" xml:space="preserve">
-    <value>Help</value>
+    <value>_Help</value>
     <comment>Used on the Main Window</comment>
   </data>
   <data name="HelpWindowTitle" xml:space="preserve">
@@ -174,6 +180,21 @@
   </data>
   <data name="MainWindowTitle" xml:space="preserve">
     <value>Generator</value>
+    <comment>Used on the Main Window</comment>
+  </data>
+  <data name="MinimizeWindowButtonUIAutomationName" xml:space="preserve">
+    <value>Minimize</value>
+  </data>
+  <data name="NewlyCreatedAllCharacterPasswordHelpText" xml:space="preserve">
+    <value>The newly created password may contain lower-case letters, upper-case letters and symbols.  By default, some screen readers do not distinguish between character case and do not read every symbol.  If you want to hear the entire password, you may need to use a feature which reads all characters and each letter’s case.  Note that character case is important because it improves the password’s security.  All of the characters and symbols in a generated password should be used because it makes the password more secure.</value>
+    <comment>Used on the Main Window</comment>
+  </data>
+  <data name="NewlyCreatedAlphaNumericPasswordHelpText" xml:space="preserve">
+    <value>The newly created password may contain lower-case and upper-case characters.  Your screen reader may not distinguish between character case by default.  Please configure it to do so if you want to copy down the password.  Note using lower-case and upper-case characters in a password makes the password much more secure.</value>
+    <comment>Used on the Main Window</comment>
+  </data>
+  <data name="NewlyCreatedPasswordLabel" xml:space="preserve">
+    <value>Newly Created Password</value>
     <comment>Used on the Main Window</comment>
   </data>
   <data name="NewPasswordCharacterSetLabel" xml:space="preserve">

--- a/EasyToUseGenerator/StandardWindow.cs
+++ b/EasyToUseGenerator/StandardWindow.cs
@@ -73,6 +73,8 @@ namespace EasyToUseGenerator
         {
             SetClickedEventHandlerOnButton("MinimizeButton", OnMinimizeButtonClicked);
             SetClickedEventHandlerOnButton("CloseButton", OnClosedButtonClicked);
+
+            this.ShowInTaskbar = (this.Owner == null);
             return;
 
 


### PR DESCRIPTION
**Major Changes**
- Fixed UI Automation Accessibility bugs
    - Added missing UI Automation Names
    - Added missing Labeled By UI Automation properties
    - Changed the UI Automation type from edit to text for read only text boxes.
- Added UI Automation help text to the newly created password text box
- Fixed a keyboard navigation bugs
    - The Create New Password window created the wrong type of password if the keyboard was used to select a password character set radio button.  The bug occurred because clicked event hander was used instead of the button checked event handler.
    - Added access keys (ALT+Letter) to buttons
    - Removed the Generator version number text box from the tab order.
    - Fixed a bug where Generator’s dialog boxes showed up in the ALT+TAB window.  Now only the main window shows up in the ALT+Tab window.

**Minor changes**
- Removed unnecessary XML properties from XAML files (x:Name, Target, etc.)

**How tested**
- I used Windows Narrator, Accessibility Insights and manual testing to test these changes.




