### PR TITLE
Bug Fix - The Help window now displays the right version number

### DIFF
--- a/EasyToUseGenerator/HelpWindow.xaml.cs
+++ b/EasyToUseGenerator/HelpWindow.xaml.cs
@@ -35,7 +35,7 @@ namespace EasyToUseGenerator
                     UserInterface.GeneratorNameAndVersionFormatString, 
                     currentExecutable.Version.Major, 
                     currentExecutable.Version.Minor, 
-                    currentExecutable.Version.Revision);
+                    currentExecutable.Version.Build);
             }
         }
         


### PR DESCRIPTION
The last part of the program's version number was wrong.  Version numbers are in the following format: x.y.z .  The z number was wrong because it used the revision part of the version number instead of the build part of the version number.