### PR TITLE
Code cleanup and fixed documentation typo

### DIFF
--- a/Documentation/CommandLineAppUsage.md
+++ b/Documentation/CommandLineAppUsage.md
@@ -26,7 +26,7 @@ Generator /Help
      If this command is specified, a new password is generated using only
      numbers.  This type of passwords is typically called a PIN.  PINs should
      only be used on devices which limit the number of attempts.  iPhone lock 
-     screens, smart cards and USB security keys are examples are things which 
+     screens, smart cards and USB security keys are examples of things which 
      limit the number of PIN guesses.  PINs should never be used for web 
      sites, computers or any password for a remote device.  Note that Windows 
      has PINs and passwords.  On Windows, passwords should be complex (have

--- a/EasyToUseGenerator/App.xaml
+++ b/EasyToUseGenerator/App.xaml
@@ -35,6 +35,7 @@
 
     <Application.Resources>
 
+        <!-- Standard veritical spaces -->
         <Thickness x:Key="StandardVerticalSpaceBetweenItemsMargin"
                    Left="0"
                    Top="5"
@@ -42,17 +43,28 @@
                    Bottom="0">
         </Thickness>
 
+        <Thickness x:Key="Standard_Medium_VerticalSpaceBetweenItemsMargin"
+                   Left="0"
+                   Top="10"
+                   Right="0"
+                   Bottom="0">
+        </Thickness>
 
-        
-        <Thickness x:Key="StandardLargeVerticalSpaceBetweenItemsMargin"
+        <Thickness x:Key="Standard_Large_VerticalSpaceBetweenItemsMargin"
                    Left="0"
                    Top="20"
                    Right="0"
                    Bottom="0">
         </Thickness>
 
+        <Thickness x:Key="Standard_Large_VerticalSpaceBetweenItemsMarginForLabels"
+                   Left="0"
+                   Top="20"
+                   Right="0"
+                   Bottom="5">
+        </Thickness>
 
-
+        <!-- Standard horizontal space -->
         <Thickness x:Key="StandardHorizonalSpaceBetweenItemsMargin"
                    Left="5"
                    Top="0"

--- a/EasyToUseGenerator/AssemblyInfo.cs
+++ b/EasyToUseGenerator/AssemblyInfo.cs
@@ -25,10 +25,10 @@
 using System.Windows;
 
 [assembly: ThemeInfo(
-    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-                                     //(used if a resource is not found in the page,
+    ResourceDictionaryLocation.None, // Where theme specific resource dictionaries are located
+                                     // (used if a resource is not found in the page,
                                      // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-                                              //(used if a resource is not found in the page,
+    ResourceDictionaryLocation.SourceAssembly // Where the generic resource dictionary is located
+                                              // (used if a resource is not found in the page,
                                               // app, or any theme specific resource dictionaries)
 )]

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -23,22 +23,22 @@
 -->
 
 <local:StandardWindow x:Class="EasyToUseGenerator.CreateNewPasswordWindow"
-                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:local="clr-namespace:EasyToUseGenerator"
-                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:local="clr-namespace:EasyToUseGenerator"
+                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
                           
-                        Title="{x:Static resources:UserInterface.CreateNewPasswordWindowTitle}"
+                      Title="{x:Static resources:UserInterface.CreateNewPasswordWindowTitle}"
 
-                        ResizeMode="NoResize"
-                        WindowStartupLocation="CenterOwner"
+                      ResizeMode="NoResize"
+                      WindowStartupLocation="CenterOwner"
                       
-                        Style="{StaticResource StandardWindowStyle}"
+                      Style="{StaticResource StandardWindowStyle}"
                                             
-                        TitleBarBackground="DarkSlateGray"
+                      TitleBarBackground="DarkSlateGray"
                       
-                        Height="270" 
-                        Width="385">
+                      Height="270" 
+                      Width="385">
 
     <Window.Resources>
         <local:BoolNotOperationConverter x:Key="BoolNotOperationConverter"/>

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -27,7 +27,7 @@
                       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                       xmlns:local="clr-namespace:EasyToUseGenerator"
                       xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
-                          
+                      
                       Title="{x:Static resources:UserInterface.CreateNewPasswordWindowTitle}"
 
                       ResizeMode="NoResize"

--- a/EasyToUseGenerator/CreateNewPasswordWindow.xaml
+++ b/EasyToUseGenerator/CreateNewPasswordWindow.xaml
@@ -23,22 +23,22 @@
 -->
 
 <local:StandardWindow x:Class="EasyToUseGenerator.CreateNewPasswordWindow"
-                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:local="clr-namespace:EasyToUseGenerator"
-                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
-                      
-                      Title="{x:Static resources:UserInterface.CreateNewPasswordWindowTitle}"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:local="clr-namespace:EasyToUseGenerator"
+                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                          
+                        Title="{x:Static resources:UserInterface.CreateNewPasswordWindowTitle}"
 
-                      ResizeMode="NoResize"
-                      WindowStartupLocation="CenterOwner"
+                        ResizeMode="NoResize"
+                        WindowStartupLocation="CenterOwner"
                       
-                      Style="{StaticResource StandardWindowStyle}"
+                        Style="{StaticResource StandardWindowStyle}"
                                             
-                      TitleBarBackground="DarkSlateGray"
+                        TitleBarBackground="DarkSlateGray"
                       
-                      Height="270" 
-                      Width="385">
+                        Height="270" 
+                        Width="385">
 
     <Window.Resources>
         <local:BoolNotOperationConverter x:Key="BoolNotOperationConverter"/>
@@ -65,7 +65,7 @@
                          IsChecked="{Binding IsAnyKeyWhichCanBeTypedRadioButtonChecked, Mode=OneTime}"
                          Checked="OnAnyKeyWhichCanBeTypedRadioButtonChecked"
                          
-                           Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
+                         Style="{StaticResource CharacterSetRadioButtonGroupStyle}"/>
 
             <RadioButton Content="{x:Static resources:UserInterface.LettersAndNumbersRadioButtonText}"
                          ToolTip="{x:Static resources:UserInterface.LettersAndNumbersRadioButtonToolTipText}"
@@ -85,7 +85,7 @@
         <Label x:Name="newPasswordLengthLabel"
                Content="{x:Static resources:UserInterface.NewPasswordLengthLabel}"
                Target="{Binding ElementName=passwordLengthTextBox}"
-               Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"
+               Margin="{StaticResource Standard_Large_VerticalSpaceBetweenItemsMargin}"
                Style="{StaticResource StandardLabelStyle}"/>
         
         <!-- The max text length is 10 because it makes it easier to edit numbers. Valid password lengths are between 1 and 38 characters. -->
@@ -131,11 +131,11 @@
                   
                   Style="{StaticResource StandardCheckBoxStyle}"
                   
-                  Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"/>
+                  Margin="{StaticResource Standard_Large_VerticalSpaceBetweenItemsMargin}"/>
 
         <!-- Button Stack Panel -->
         <StackPanel Orientation="Horizontal"
-                    Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}">
+                    Margin="{StaticResource Standard_Large_VerticalSpaceBetweenItemsMargin}">
 
             <Button Content="{x:Static resources:UserInterface.CreatePasswordButtonText}"
                     Click="OnCreatePasswordClicked"

--- a/EasyToUseGenerator/HelpWindow.xaml
+++ b/EasyToUseGenerator/HelpWindow.xaml
@@ -1,20 +1,20 @@
 ﻿<local:StandardWindow x:Class="EasyToUseGenerator.HelpWindow"
-                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:local="clr-namespace:EasyToUseGenerator"
-                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:local="clr-namespace:EasyToUseGenerator"
+                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
 
-                      Title="{x:Static resources:UserInterface.HelpWindowTitle}" 
+                        Title="{x:Static resources:UserInterface.HelpWindowTitle}" 
 
-                      ResizeMode="NoResize"
-                      WindowStartupLocation="CenterOwner"
+                        ResizeMode="NoResize"
+                        WindowStartupLocation="CenterOwner"
                       
-                      Style="{StaticResource StandardWindowStyle}"
+                        Style="{StaticResource StandardWindowStyle}"
                       
-                      TitleBarBackground="DarkSlateGray"
+                        TitleBarBackground="DarkSlateGray"
                       
-                      Height="290" 
-                      Width="398">
+                        Height="290" 
+                        Width="398">
     
     <local:StandardWindow.Resources>
         <Style x:Key="HyperLinkButtonStyle" 
@@ -69,7 +69,7 @@
                 Click="OnDocumentationClicked"
                 
                 Style="{StaticResource HyperLinkButtonStyle}"
-                Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"/>
+                Margin="{StaticResource Standard_Large_VerticalSpaceBetweenItemsMargin}"/>
 
         <Button Content="{x:Static resources:UserInterface.PasswordAdviceButtonText}"
                 Click="OnPasswordAdviceClicked"
@@ -99,6 +99,6 @@
                 Click="OnOKClicked"
                 HorizontalAlignment="Right"
                 Style="{StaticResource StandardButtonStyle}"
-                Margin="{StaticResource StandardLargeVerticalSpaceBetweenItemsMargin}"/>
+                Margin="{StaticResource Standard_Large_VerticalSpaceBetweenItemsMargin}"/>
     </StackPanel>
 </local:StandardWindow>

--- a/EasyToUseGenerator/HelpWindow.xaml
+++ b/EasyToUseGenerator/HelpWindow.xaml
@@ -1,20 +1,20 @@
 ﻿<local:StandardWindow x:Class="EasyToUseGenerator.HelpWindow"
-                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:local="clr-namespace:EasyToUseGenerator"
-                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:local="clr-namespace:EasyToUseGenerator"
+                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
 
-                        Title="{x:Static resources:UserInterface.HelpWindowTitle}" 
+                      Title="{x:Static resources:UserInterface.HelpWindowTitle}" 
 
-                        ResizeMode="NoResize"
-                        WindowStartupLocation="CenterOwner"
+                      ResizeMode="NoResize"
+                      WindowStartupLocation="CenterOwner"
                       
-                        Style="{StaticResource StandardWindowStyle}"
+                      Style="{StaticResource StandardWindowStyle}"
                       
-                        TitleBarBackground="DarkSlateGray"
+                      TitleBarBackground="DarkSlateGray"
                       
-                        Height="290" 
-                        Width="398">
+                      Height="290" 
+                      Width="398">
     
     <local:StandardWindow.Resources>
         <Style x:Key="HyperLinkButtonStyle" 

--- a/EasyToUseGenerator/MainWindow.xaml
+++ b/EasyToUseGenerator/MainWindow.xaml
@@ -23,19 +23,19 @@
 -->
     
 <local:StandardWindow x:Class="EasyToUseGenerator.MainWindow"
-                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                        xmlns:local="clr-namespace:EasyToUseGenerator"
-                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                      xmlns:local="clr-namespace:EasyToUseGenerator"
+                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
         
-        Title="{x:Static resources:UserInterface.MainWindowTitle}"
+                      Title="{x:Static resources:UserInterface.MainWindowTitle}"
 
-        ResizeMode="CanMinimize"
+                      ResizeMode="CanMinimize"
                       
-        Style="{StaticResource StandardWindowStyle}"
+                      Style="{StaticResource StandardWindowStyle}"
                       
-        Width="570"
-        Height="301">
+                      Width="570"
+                      Height="301">
 
     <StackPanel Style="{StaticResource StandardMainStackPanelStyle}">
         <Label Content="{x:Static resources:UserInterface.NewlyCreatedPasswordLabel}"

--- a/EasyToUseGenerator/MainWindow.xaml
+++ b/EasyToUseGenerator/MainWindow.xaml
@@ -23,10 +23,10 @@
 -->
     
 <local:StandardWindow x:Class="EasyToUseGenerator.MainWindow"
-                      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                      xmlns:local="clr-namespace:EasyToUseGenerator"
-                      xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
+                        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                        xmlns:local="clr-namespace:EasyToUseGenerator"
+                        xmlns:resources="clr-namespace:EasyToUseGenerator.Resources"
         
         Title="{x:Static resources:UserInterface.MainWindowTitle}"
 
@@ -52,7 +52,7 @@
         <Label Content="{x:Static resources:UserInterface.PasswordStrengthLabel}"
               
                Style="{StaticResource StandardLabelStyle}"
-               Margin="0,10,0,0"/>
+               Margin="{StaticResource Standard_Medium_VerticalSpaceBetweenItemsMargin}"/>
         
         <TextBlock Text="{Binding Path=PasswordStrength, Mode=OneWay}"
                                
@@ -63,7 +63,7 @@
         <Label Content="{x:Static resources:UserInterface.PasswordStrengthDescriptionLabel}"
                
                Style="{StaticResource StandardLabelStyle}"
-               Margin="0,10,0,0"/>
+               Margin="{StaticResource Standard_Medium_VerticalSpaceBetweenItemsMargin}"/>
 
         <TextBlock Text="{Binding Path=PasswordStrengthDescription, Mode=OneWay}"
                                
@@ -73,24 +73,21 @@
                    Margin="{StaticResource StandardVerticalSpaceBetweenItemsMargin}"/>
 
         <StackPanel Orientation="Horizontal"
-                    Margin="0,10,0,0">
+                    Margin="{StaticResource Standard_Medium_VerticalSpaceBetweenItemsMargin}">
             
             <Button Content="{x:Static resources:UserInterface.CopyToClipboardButtonText}"
                     Click="OnCopyToClipBoardPressed"
                     
                     IsDefault="True"
-                    TabIndex="0"
-                    
+                                        
                     Style="{StaticResource StandardButtonStyle}"/>
 
             <Button Content="{x:Static resources:UserInterface.CreateNewPasswordButtonText}"
                     Click="OnCreateNewPasswordClicked"
                     
-                    TabIndex="1"
-                    
                     Style="{StaticResource StandardButtonStyle}"
                     
-                    Margin="5,0,0,0"/>
+                    Margin="{StaticResource StandardHorizonalSpaceBetweenItemsMargin}"/>
 
             <Button Content="{x:Static resources:UserInterface.HelpButtonText}"
                     Click="OnHelpClicked"
@@ -99,7 +96,7 @@
                     
                     Style="{StaticResource StandardButtonStyle}"
 
-                    Margin="5,0,0,0"/>
+                    Margin="{StaticResource StandardHorizonalSpaceBetweenItemsMargin}"/>
         </StackPanel>
     </StackPanel>
 </local:StandardWindow>

--- a/EasyToUseGeneratorTests/AppSettingsTests.cs
+++ b/EasyToUseGeneratorTests/AppSettingsTests.cs
@@ -27,8 +27,6 @@ using EasyToUseGenerator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Moq.Language.Flow;
-using System;
-using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace EasyToUseGenerator.Tests

--- a/EasyToUseGeneratorTests/PasswordLengthBindingValidationRuleTests.cs
+++ b/EasyToUseGeneratorTests/PasswordLengthBindingValidationRuleTests.cs
@@ -1,11 +1,7 @@
 ﻿using EasyToUseGenerator;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Controls;
 using TestUtil;
 


### PR DESCRIPTION
- Fixed a typo in the documentation for Generator’s command line version
- Made it easier to distinguish between the standard, medium and large standard vertical space XAML thicknesses
- Removed some unnecessary C# using statements
- Removed some unnecessary XAML 
- Replaced hard coded vertical and horizonal spaces with standard XAML thicknesses on the Main Window's XAML file

